### PR TITLE
Respect target window for new source input streams (issue 12)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <jmh.version>1.12</jmh.version>
     <nukleus.plugin.version>0.7.3</nukleus.plugin.version>
     <nukleus.version>0.2</nukleus.version>
-    <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
+    <nukleus.http.spec.version>0.11</nukleus.http.spec.version>
     <reaktor.test.version>0.2</reaktor.test.version>
     <reaktor.version>0.1</reaktor.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <jmh.version>1.12</jmh.version>
     <nukleus.plugin.version>0.7.3</nukleus.plugin.version>
     <nukleus.version>0.2</nukleus.version>
-    <nukleus.http.spec.version>0.8</nukleus.http.spec.version>
+    <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
     <reaktor.test.version>0.2</reaktor.test.version>
     <reaktor.version>0.1</reaktor.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
@@ -153,7 +153,7 @@ public final class SourceInputStreamFactory
             }
         }
 
-        private void streamAwaitingTargetWindow(
+        private void streamBeforeWindowsAreAligned(
             int msgTypeId,
             DirectBuffer buffer,
             int index,
@@ -404,8 +404,8 @@ public final class SourceInputStreamFactory
                         assert dataLength <= buffer.capacity();
                         buffer.putBytes(0, payload, endOfHeadersAt, dataLength);
                         slotPosition = dataLength;
-                        streamState = this::streamAwaitingTargetWindow;
-                        throttleState = this::beforeInitialWindow;
+                        streamState = this::streamBeforeWindowsAreAligned;
+                        throttleState = this::beforeeforeWindowsAreAligned;
                     }
                     else
                     {
@@ -446,8 +446,8 @@ public final class SourceInputStreamFactory
                     assert length <= buffer.capacity();
                     buffer.putBytes(0, payload, endOfHeadersAt, length);
                     slotPosition = length;
-                    streamState = this::streamAwaitingTargetWindow;
-                    throttleState = this::beforeInitialWindow;
+                    streamState = this::streamBeforeWindowsAreAligned;
+                    throttleState = this::beforeeforeWindowsAreAligned;
                 }
             }
             return limit;
@@ -660,7 +660,7 @@ public final class SourceInputStreamFactory
             }
         }
 
-        private void beforeInitialWindow(
+        private void beforeeforeWindowsAreAligned(
             int msgTypeId,
             DirectBuffer buffer,
             int index,
@@ -669,7 +669,7 @@ public final class SourceInputStreamFactory
             switch (msgTypeId)
             {
             case WindowFW.TYPE_ID:
-                processInitialWindow(buffer, index, length);
+                processWindowBeforeAlignment(buffer, index, length);
                 break;
             case ResetFW.TYPE_ID:
                 processReset(buffer, index, length);
@@ -700,7 +700,7 @@ public final class SourceInputStreamFactory
             }
         }
 
-        private void processInitialWindow(DirectBuffer buffer, int index, int length)
+        private void processWindowBeforeAlignment(DirectBuffer buffer, int index, int length)
         {
             windowRO.wrap(buffer, index, index + length);
             int update = windowRO.update();
@@ -716,7 +716,7 @@ public final class SourceInputStreamFactory
             decode(data, slotOffset, slotOffset + bytesToWrite);
             availableTargetWindow -= bytesToWrite;
 
-            // Continue slabbing incoming data until available target window has caught up
+            // Continue slabbing incoming data until target window updates have caught up
             // with the initial window we gave to source
             slotOffset += bytesToWrite;
             int bytesLeft = slotPosition - slotOffset;

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
@@ -405,7 +405,7 @@ public final class SourceInputStreamFactory
                         buffer.putBytes(0, payload, endOfHeadersAt, dataLength);
                         slotPosition = dataLength;
                         streamState = this::streamBeforeWindowsAreAligned;
-                        throttleState = this::beforeeforeWindowsAreAligned;
+                        throttleState = this::beforeWindowsAreAligned;
                     }
                     else
                     {
@@ -447,7 +447,7 @@ public final class SourceInputStreamFactory
                     buffer.putBytes(0, payload, endOfHeadersAt, length);
                     slotPosition = length;
                     streamState = this::streamBeforeWindowsAreAligned;
-                    throttleState = this::beforeeforeWindowsAreAligned;
+                    throttleState = this::beforeWindowsAreAligned;
                 }
             }
             return limit;
@@ -660,7 +660,7 @@ public final class SourceInputStreamFactory
             }
         }
 
-        private void beforeeforeWindowsAreAligned(
+        private void beforeWindowsAreAligned(
             int msgTypeId,
             DirectBuffer buffer,
             int index,

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
@@ -711,16 +711,17 @@ public final class SourceInputStreamFactory
 
         private void processDeferredData()
         {
-            int bytesToWrite = Math.min(slotPosition - slotOffset, availableTargetWindow);
+            int bytesDeferred = slotPosition - slotOffset;
+            int writableBytes = Math.min(bytesDeferred, availableTargetWindow);
             MutableDirectBuffer data = slab.buffer(slotIndex);
-            decode(data, slotOffset, slotOffset + bytesToWrite);
-            availableTargetWindow -= bytesToWrite;
+            decode(data, slotOffset, slotOffset + writableBytes);
+            availableTargetWindow -= writableBytes;
 
             // Continue slabbing incoming data until target window updates have caught up
             // with the initial window we gave to source
-            slotOffset += bytesToWrite;
-            int bytesLeft = slotPosition - slotOffset;
-            if (sourceUpdateDeferred >= 0 && bytesLeft == 0)
+            slotOffset += writableBytes;
+            bytesDeferred -= writableBytes;
+            if (sourceUpdateDeferred >= 0 && bytesDeferred == 0)
             {
                 slab.release(slotIndex);
                 slotIndex = SLOT_NOT_AVAILABLE;

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
@@ -17,6 +17,7 @@ package org.reaktivity.nukleus.http.internal.routable.stream;
 
 import static java.lang.Integer.parseInt;
 import static org.reaktivity.nukleus.http.internal.routable.Route.headersMatch;
+import static org.reaktivity.nukleus.http.internal.routable.stream.Slab.SLOT_NOT_AVAILABLE;
 import static org.reaktivity.nukleus.http.internal.router.RouteKind.OUTPUT_ESTABLISHED;
 import static org.reaktivity.nukleus.http.internal.util.BufferUtil.limitOfBytes;
 
@@ -98,8 +99,10 @@ public final class SourceInputStreamFactory
         private MessageHandler streamState;
         private MessageHandler throttleState;
         private DecoderState decoderState;
-        private int slotIndex;
+        private int slotIndex = SLOT_NOT_AVAILABLE;
+        private int slotOffset = 0;
         private int slotPosition;
+        private boolean endRequested;
 
         private long sourceId;
 
@@ -146,6 +149,26 @@ public final class SourceInputStreamFactory
             else
             {
                 processUnexpected(buffer, index, length);
+            }
+        }
+
+        private void streamAwaitingTargetWindow(
+            int msgTypeId,
+            DirectBuffer buffer,
+            int index,
+            int length)
+        {
+            switch (msgTypeId)
+            {
+            case DataFW.TYPE_ID:
+                deferData(buffer, index, length);
+                break;
+            case EndFW.TYPE_ID:
+                deferEnd(buffer, index, length);
+                break;
+            default:
+                processUnexpected(buffer, index, length);
+                break;
             }
         }
 
@@ -286,12 +309,16 @@ public final class SourceInputStreamFactory
             {
                 final OctetsFW payload = dataRO.payload();
                 final int limit = payload.limit();
-
                 int offset = payload.offset();
-                while (offset < limit)
-                {
-                    offset = decoderState.decode(buffer, offset, limit);
-                }
+                decode(payload.buffer(), offset, limit);
+            }
+        }
+
+        private void decode(DirectBuffer buffer, int offset, int limit)
+        {
+            while (offset < limit)
+            {
+                offset = decoderState.decode(buffer, offset, limit);
             }
         }
 
@@ -302,11 +329,46 @@ public final class SourceInputStreamFactory
         {
             endRO.wrap(buffer, index, index + length);
             final long streamId = endRO.streamId();
+            assert streamId == sourceId;
+            doEnd();
+        }
 
+        private void doEnd()
+        {
             decoderState = (b, o, l) -> o;
 
-            source.removeStream(streamId);
+            source.removeStream(sourceId);
             target.removeThrottle(targetId);
+            if (slotIndex != SLOT_NOT_AVAILABLE)
+            {
+                slab.release(slotIndex);
+            }
+        }
+
+        private void deferData(
+            DirectBuffer buffer,
+            int index,
+            int length)
+        {
+            dataRO.wrap(buffer, index, index + length);
+            final OctetsFW payload = dataRO.payload();
+            int offset = payload.offset();
+            final int dataLength = payload.limit() - offset;
+            MutableDirectBuffer store = slab.buffer(slotIndex);
+            store.putBytes(slotPosition, payload.buffer(), offset, dataLength);
+            slotPosition += dataLength;
+        }
+
+        private void deferEnd(
+            DirectBuffer buffer,
+            int index,
+            int length)
+        {
+            endRO.wrap(buffer, index, index + length);
+            final long streamId = endRO.streamId();
+            assert streamId == sourceId;
+
+            endRequested = true;
         }
 
         private int defragmentHttpBegin(
@@ -319,7 +381,6 @@ public final class SourceInputStreamFactory
             {
                 slab.release(slotIndex);
                 processInvalidRequest(limit - offset, "HTTP/1.1 431 Request Header Fields Too Large\r\n\r\n");
-                return limit;
             }
             else
             {
@@ -327,17 +388,27 @@ public final class SourceInputStreamFactory
                 MutableDirectBuffer buffer = slab.buffer(slotIndex);
                 buffer.putBytes(slotPosition, payload, offset, length);
                 slotPosition += length;
-                if (endOfHeadersAt == -1)
-                {
-                    return limit;
-                }
-                else
+                if (endOfHeadersAt != -1)
                 {
                     decodeCompleteHttpBegin(buffer, 0, slotPosition);
-                    slab.release(slotIndex);
-                    return endOfHeadersAt;
+                    if (endOfHeadersAt < limit)
+                    {
+                        // Not all source data was consumed, delay processing it until target gives us window
+                        slotPosition = slotOffset = 0;
+                        int dataLength = limit - endOfHeadersAt;
+                        assert dataLength <= buffer.capacity();
+                        buffer.putBytes(0, payload, endOfHeadersAt, dataLength);
+                        slotPosition = dataLength;
+                        streamState = this::streamAwaitingTargetWindow;
+                        throttleState = this::beforeInitialWindow;
+                    }
+                    else
+                    {
+                        slab.release(slotIndex);
+                    }
                 }
             }
+            return limit;
         }
 
         private int decodeHttpBegin(
@@ -349,20 +420,32 @@ public final class SourceInputStreamFactory
             if (endOfHeadersAt == -1)
             {
                 slotIndex = slab.acquire(sourceId);
-                slotPosition = 0;
+                slotPosition = slotOffset = 0;
                 int length = limit - offset;
                 MutableDirectBuffer buffer = slab.buffer(slotIndex);
                 assert length <= buffer.capacity();
                 buffer.putBytes(0, payload, offset, length);
                 slotPosition = length;
                 decoderState = this::defragmentHttpBegin;
-                return limit;
             }
             else
             {
                 decodeCompleteHttpBegin(payload, offset, endOfHeadersAt - offset);
-                return endOfHeadersAt;
+                if (endOfHeadersAt < limit)
+                {
+                    // Not all source data was consumed, delay processing it until target gives us window
+                    slotIndex = slab.acquire(sourceId);
+                    slotPosition = slotOffset = 0;
+                    int length = limit - endOfHeadersAt;
+                    MutableDirectBuffer buffer = slab.buffer(slotIndex);
+                    assert length <= buffer.capacity();
+                    buffer.putBytes(0, payload, endOfHeadersAt, length);
+                    slotPosition = length;
+                    streamState = this::streamAwaitingTargetWindow;
+                    throttleState = this::beforeInitialWindow;
+                }
             }
+            return limit;
         }
 
         private void decodeCompleteHttpBegin(
@@ -566,6 +649,26 @@ public final class SourceInputStreamFactory
             }
         }
 
+        private void beforeInitialWindow(
+            int msgTypeId,
+            DirectBuffer buffer,
+            int index,
+            int length)
+        {
+            switch (msgTypeId)
+            {
+            case WindowFW.TYPE_ID:
+                processInitialWindow(buffer, index, length);
+                break;
+            case ResetFW.TYPE_ID:
+                processReset(buffer, index, length);
+                break;
+            default:
+                // ignore
+                break;
+            }
+        }
+
         private void beforeWindowOrReset(
             int msgTypeId,
             DirectBuffer buffer,
@@ -583,6 +686,34 @@ public final class SourceInputStreamFactory
             default:
                 // ignore
                 break;
+            }
+        }
+
+        private void processInitialWindow(DirectBuffer buffer, int index, int length)
+        {
+            windowRO.wrap(buffer, index, index + length);
+            int update = windowRO.update();
+            doSourceWindow(update);
+
+            // Process any deferred source data
+            int dataLength = Math.min(slotPosition, update);
+            MutableDirectBuffer data = slab.buffer(slotIndex);
+            decode(data, slotOffset, dataLength);
+            if (dataLength < slotPosition)
+            {
+                slotOffset += dataLength;
+            }
+            else
+            {
+                slab.release(slotIndex);
+                slotIndex = SLOT_NOT_AVAILABLE;
+                if (endRequested)
+                {
+                    doEnd();
+                    return;
+                }
+                streamState = this::streamAfterBeginOrData;
+                throttleState = this::beforeWindowOrReset;
             }
         }
 
@@ -615,7 +746,10 @@ public final class SourceInputStreamFactory
             int length)
         {
             resetRO.wrap(buffer, index, index + length);
-
+            if (slotIndex != SLOT_NOT_AVAILABLE)
+            {
+                slab.release(slotIndex);
+            }
             source.doReset(sourceId);
         }
     }

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
@@ -716,10 +716,12 @@ public final class SourceInputStreamFactory
                 if (endRequested)
                 {
                     doEnd();
-                    return;
                 }
-                streamState = this::streamAfterBeginOrData;
-                throttleState = this::beforeWindowOrReset;
+                else
+                {
+                    streamState = this::streamAfterBeginOrData;
+                    throttleState = this::beforeWindowOrReset;
+                }
             }
         }
 

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlIT.java
@@ -78,8 +78,8 @@ public class FlowControlIT
     @Test
     @Specification({
         "${route}/input/new/controller",
-        "${streams}/request.with.content.fragmented.by.target.window/server/source",
-        "${streams}/request.with.content.fragmented.by.target.window/server/target" })
+        "${streams}/request.with.content.flow.controlled/server/source",
+        "${streams}/request.with.content.flow.controlled/server/target" })
     public void shouldSplitRequestDataToRespectTargetWindow() throws Exception
     {
         k3po.start();
@@ -90,8 +90,8 @@ public class FlowControlIT
     @Test
     @Specification({
         "${route}/input/new/controller",
-        "${streams}/request.with.fragmented.content.flow.controlled.by.target/server/source",
-        "${streams}/request.with.fragmented.content.flow.controlled.by.target/server/target" })
+        "${streams}/request.with.fragmented.content.flow.controlled/server/source",
+        "${streams}/request.with.fragmented.content.flow.controlled/server/target" })
     public void shouldSlabDataWhenTargetWindowStillNegative() throws Exception
     {
         k3po.start();

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlLimitsIT.java
@@ -31,11 +31,11 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 import org.reaktivity.nukleus.http.internal.test.SystemPropertiesRule;
 import org.reaktivity.reaktor.test.NukleusRule;
 
-public class MessageFormatLimitsIT
+public class FlowControlLimitsIT
 {
     private final K3poRule k3po = new K3poRule()
             .addScriptRoot("route", "org/reaktivity/specification/nukleus/http/control/route")
-            .addScriptRoot("streams", "org/reaktivity/specification/nukleus/http/streams/rfc7230/message.format");
+            .addScriptRoot("streams", "org/reaktivity/specification/nukleus/http/streams/rfc7230/flow.control");
 
     private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
 

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/server/rfc7230/MessageFormatIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/server/rfc7230/MessageFormatIT.java
@@ -65,18 +65,6 @@ public class MessageFormatIT
     @Test
     @Specification({
         "${route}/input/new/controller",
-        "${streams}/request.with.content.length.no.target.window/server/source",
-        "${streams}/request.with.content.length.no.target.window/server/target" })
-    public void shouldNotWriteDataToTargetWithoutWindow() throws Exception
-    {
-        k3po.start();
-        k3po.awaitBarrier("ROUTED_INPUT");
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
-        "${route}/input/new/controller",
         "${streams}/request.with.headers/server/source",
         "${streams}/request.with.headers/server/target" })
     public void shouldAcceptRequestWithHeaders() throws Exception
@@ -112,5 +100,44 @@ public class MessageFormatIT
         k3po.notifyBarrier("ROUTED_OUTPUT");
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
+        "${streams}/request.with.content.length.no.target.window/server/source",
+        "${streams}/request.with.content.length.no.target.window/server/target" })
+    public void shouldNotWriteDataToTargetWithoutWindow() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_INPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
+        "${streams}/request.with.content.length.and.end.late.target.window/server/source",
+        "${streams}/request.with.content.length.and.end.late.target.window/server/target" })
+    public void shouldNotWriteEndToTargetBeforeGettingWindowAndWritingData() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_INPUT");
+        k3po.notifyBarrier("ROUTED_OUTPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
+        "${streams}/request.fragmented.with.content.length.target.window.exhausted/server/source",
+        "${streams}/request.fragmented.with.content.length.target.window.exhausted/server/target" })
+    public void shouldRespectTargetWindow() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_INPUT");
+        k3po.notifyBarrier("ROUTED_OUTPUT");
+        k3po.finish();
+    }
+
 
 }

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/server/rfc7230/MessageFormatIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/server/rfc7230/MessageFormatIT.java
@@ -65,6 +65,18 @@ public class MessageFormatIT
     @Test
     @Specification({
         "${route}/input/new/controller",
+        "${streams}/request.with.content.length.no.target.window/server/source",
+        "${streams}/request.with.content.length.no.target.window/server/target" })
+    public void shouldNotWriteDataToTargetWithoutWindow() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_INPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
         "${streams}/request.with.headers/server/source",
         "${streams}/request.with.headers/server/target" })
     public void shouldAcceptRequestWithHeaders() throws Exception

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/server/rfc7230/MessageFormatIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/server/rfc7230/MessageFormatIT.java
@@ -118,7 +118,7 @@ public class MessageFormatIT
         "${route}/input/new/controller",
         "${streams}/request.with.content.length.and.end.late.target.window/server/source",
         "${streams}/request.with.content.length.and.end.late.target.window/server/target" })
-    public void shouldNotWriteEndToTargetBeforeGettingWindowAndWritingData() throws Exception
+    public void shouldNotProcessSourceEndBeforeGettingWindowAndWritingData() throws Exception
     {
         k3po.start();
         k3po.awaitBarrier("ROUTED_INPUT");
@@ -135,7 +135,6 @@ public class MessageFormatIT
     {
         k3po.start();
         k3po.awaitBarrier("ROUTED_INPUT");
-        k3po.notifyBarrier("ROUTED_OUTPUT");
         k3po.finish();
     }
 


### PR DESCRIPTION
This is the fix for issue #12: the sending of data frames to target input and the processing of END source input must be delayed until target has given us a window. This is done by "slabbing" any remaining data or subsequently received data after decoding an HTTP request.

Requires http spec changes (PR https://github.com/reaktivity/nukleus-http.spec/pull/12)