### PR TITLE
Flow control completion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <jmh.version>1.12</jmh.version>
     <nukleus.plugin.version>0.7.3</nukleus.plugin.version>
     <nukleus.version>0.2</nukleus.version>
-    <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
+    <nukleus.http.spec.version>0.13</nukleus.http.spec.version>
     <reaktor.test.version>0.2</reaktor.test.version>
     <reaktor.version>0.1</reaktor.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <jmh.version>1.12</jmh.version>
     <nukleus.plugin.version>0.7.3</nukleus.plugin.version>
     <nukleus.version>0.2</nukleus.version>
-    <nukleus.http.spec.version>0.11</nukleus.http.spec.version>
+    <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
     <reaktor.test.version>0.2</reaktor.test.version>
     <reaktor.version>0.1</reaktor.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/Source.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/Source.java
@@ -29,6 +29,7 @@ import org.agrona.concurrent.MessageHandler;
 import org.agrona.concurrent.ringbuffer.RingBuffer;
 import org.reaktivity.nukleus.Nukleus;
 import org.reaktivity.nukleus.http.internal.layouts.StreamsLayout;
+import org.reaktivity.nukleus.http.internal.routable.stream.Slab;
 import org.reaktivity.nukleus.http.internal.routable.stream.SourceInputStreamFactory;
 import org.reaktivity.nukleus.http.internal.routable.stream.SourceOutputStreamFactory;
 import org.reaktivity.nukleus.http.internal.routable.stream.TargetInputEstablishedStreamFactory;
@@ -84,16 +85,17 @@ public final class Source implements Nukleus
 
         Target rejectTarget = supplyTarget.apply(sourceName);
         this.streamFactories = new EnumMap<>(RouteKind.class);
+        Slab slab = new Slab(memoryForDecodeEncode, maximumHeadersSize);
         this.streamFactories.put(RouteKind.INPUT, new SourceInputStreamFactory(this, supplyRoutes, supplyTargetId,
-                rejectTarget, correlateNew, maximumHeadersSize, memoryForDecodeEncode)::newStream);
+                rejectTarget, correlateNew, slab)::newStream);
         this.streamFactories.put(RouteKind.OUTPUT_ESTABLISHED,
                 new TargetOutputEstablishedStreamFactory(this, supplyTarget, supplyTargetId, correlateEstablished,
-                        maximumHeadersSize, memoryForDecodeEncode)::newStream);
+                        slab)::newStream);
         this.streamFactories.put(RouteKind.OUTPUT,
                 new SourceOutputStreamFactory(this, supplyRoutes, supplyTargetId,
-                        correlateNew, maximumHeadersSize, memoryForDecodeEncode)::newStream);
+                        correlateNew, slab)::newStream);
         this.streamFactories.put(RouteKind.INPUT_ESTABLISHED, new TargetInputEstablishedStreamFactory(this, supplyTarget,
-                supplyTargetId, correlateEstablished, maximumHeadersSize, memoryForDecodeEncode)::newStream);
+                supplyTargetId, correlateEstablished, slab)::newStream);
 
         this.lookupEstablished = lookupEstablished;
     }

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/Source.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/Source.java
@@ -90,7 +90,8 @@ public final class Source implements Nukleus
                 new TargetOutputEstablishedStreamFactory(this, supplyTarget, supplyTargetId, correlateEstablished,
                         maximumHeadersSize, memoryForDecodeEncode)::newStream);
         this.streamFactories.put(RouteKind.OUTPUT,
-                new SourceOutputStreamFactory(this, supplyRoutes, supplyTargetId, correlateNew)::newStream);
+                new SourceOutputStreamFactory(this, supplyRoutes, supplyTargetId,
+                        correlateNew, maximumHeadersSize, memoryForDecodeEncode)::newStream);
         this.streamFactories.put(RouteKind.INPUT_ESTABLISHED, new TargetInputEstablishedStreamFactory(this, supplyTarget,
                 supplyTargetId, correlateEstablished, maximumHeadersSize, memoryForDecodeEncode)::newStream);
 

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/Slab.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/Slab.java
@@ -30,7 +30,7 @@ import org.agrona.concurrent.UnsafeBuffer;
  * to store data in it, and releasing the slot once it is no longer needed.
  * <b>Each instance of this class is assumed to be used by one and only one thread.</b>
  */
-public class Slab
+public final class Slab
 {
     public static final int NO_SLOT = -1;
 
@@ -113,6 +113,11 @@ public class Slab
             used.clear(slot);
             availableSlots++;
         }
+    }
+
+    public int slotCapacity()
+    {
+        return slotCapacity;
     }
 
 }

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
@@ -77,16 +77,15 @@ public final class SourceInputStreamFactory
         LongSupplier supplyStreamId,
         Target rejectTarget,
         LongObjectBiConsumer<Correlation> correlateNew,
-        int maximumHeadersSize,
-        int memoryForDecode)
+        Slab slab)
     {
         this.source = source;
         this.supplyRoutes = supplyRoutes;
         this.supplyStreamId = supplyStreamId;
         this.rejectTarget = rejectTarget;
         this.correlateNew = correlateNew;
-        this.maximumHeadersSize = maximumHeadersSize;
-        this.slab = new Slab(memoryForDecode, maximumHeadersSize);
+        this.slab = slab;
+        this.maximumHeadersSize = slab.slotCapacity();
     }
 
     public MessageHandler newStream()

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
@@ -18,6 +18,7 @@ package org.reaktivity.nukleus.http.internal.routable.stream;
 import static java.lang.Character.toUpperCase;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.reaktivity.nukleus.http.internal.routable.Route.headersMatch;
+import static org.reaktivity.nukleus.http.internal.routable.stream.Slab.NO_SLOT;
 import static org.reaktivity.nukleus.http.internal.router.RouteKind.INPUT_ESTABLISHED;
 
 import java.util.Collections;
@@ -32,7 +33,6 @@ import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.MessageHandler;
-import org.agrona.concurrent.UnsafeBuffer;
 import org.reaktivity.nukleus.http.internal.routable.Correlation;
 import org.reaktivity.nukleus.http.internal.routable.Route;
 import org.reaktivity.nukleus.http.internal.routable.Source;
@@ -73,16 +73,21 @@ public final class SourceOutputStreamFactory
     private final LongFunction<List<Route>> supplyRoutes;
     private final LongObjectBiConsumer<Correlation> correlateNew;
 
+    private final Slab slab;
+
     public SourceOutputStreamFactory(
         Source source,
         LongFunction<List<Route>> supplyRoutes,
         LongSupplier supplyTargetId,
-        LongObjectBiConsumer<Correlation> correlateNew)
+        LongObjectBiConsumer<Correlation> correlateNew,
+        int maximumHeadersSize,
+        int memoryForEncode)
     {
         this.source = source;
         this.supplyTargetId = supplyTargetId;
         this.supplyRoutes = supplyRoutes;
         this.correlateNew = correlateNew;
+        this.slab = new Slab(memoryForEncode, maximumHeadersSize);
     }
 
     public MessageHandler newStream()
@@ -101,11 +106,15 @@ public final class SourceOutputStreamFactory
         private Target target;
         private long targetId;
         private int window;
+        private int slotIndex;
+        private int slotPosition;
+        private int slotOffset;
+        private boolean endDeferred;
 
         private SourceOutputStream()
         {
-            this.streamState = this::beforeBegin;
-            this.throttleState = this::throttleSkipNextWindow;
+            this.streamState = this::streamBeforeBegin;
+            this.throttleState = this::throttleBeforeBegin;
         }
 
         private void handleStream(
@@ -117,9 +126,9 @@ public final class SourceOutputStreamFactory
             streamState.onMessage(msgTypeId, buffer, index, length);
         }
 
-        private void beforeBegin(
+        private void streamBeforeBegin(
             int msgTypeId,
-            MutableDirectBuffer buffer,
+            DirectBuffer buffer,
             int index,
             int length)
         {
@@ -133,7 +142,25 @@ public final class SourceOutputStreamFactory
             }
         }
 
-        private void afterBeginOrData(
+        private void streamBeforeHeadersWritten(
+            int msgTypeId,
+            DirectBuffer buffer,
+            int index,
+            int length)
+        {
+            switch (msgTypeId)
+            {
+            case EndFW.TYPE_ID:
+                endDeferred = true;
+                break;
+            default:
+                slab.release(slotIndex);
+                processUnexpected(buffer, index, length);
+                break;
+            }
+        }
+
+        private void streamAfterBeginOrData(
             int msgTypeId,
             DirectBuffer buffer,
             int index,
@@ -153,7 +180,7 @@ public final class SourceOutputStreamFactory
             }
         }
 
-        private void afterEnd(
+        private void streamAfterEnd(
             int msgTypeId,
             DirectBuffer buffer,
             int index,
@@ -162,7 +189,7 @@ public final class SourceOutputStreamFactory
             processUnexpected(buffer, index, length);
         }
 
-        private void afterReplyOrReset(
+        private void streamAfterReplyOrReset(
             int msgTypeId,
             MutableDirectBuffer buffer,
             int index,
@@ -182,7 +209,7 @@ public final class SourceOutputStreamFactory
 
                 source.removeStream(streamId);
 
-                this.streamState = this::afterEnd;
+                this.streamState = this::streamAfterEnd;
             }
         }
 
@@ -268,13 +295,25 @@ public final class SourceOutputStreamFactory
                                            .append(" HTTP/1.1").append("\r\n")
                                            .append("Host").append(": ").append(pseudoHeaders[AUTHORITY]).append("\r\n")
                                            .append(headersChars).append("\r\n").toString();
-
-                final DirectBuffer payload = new UnsafeBuffer(payloadChars.getBytes(US_ASCII));
-
-                target.doData(targetId, payload, 0, payload.capacity());
-
-                this.streamState = this::afterBeginOrData;
-                this.throttleState = this::throttleNextThenSkipWindow;
+                slotIndex = slab.acquire(sourceId);
+                slotPosition = 0;
+                MutableDirectBuffer slot = slab.buffer(slotIndex);
+                if (payloadChars.length() > slot.capacity())
+                {
+                    // TODO: diagnostics (reset reason?)
+                    source.doReset(sourceId);
+                    target.removeThrottle(targetId);
+                    source.removeStream(sourceId);
+                }
+                else
+                {
+                    byte[] bytes = payloadChars.getBytes(US_ASCII);
+                    slot.putBytes(0, bytes);
+                    slotPosition = bytes.length;
+                    slotOffset = 0;
+                    this.streamState = this::streamBeforeHeadersWritten;
+                    this.throttleState = this::throttleBeforeHeadersWritten;
+                }
             }
             else
             {
@@ -307,9 +346,14 @@ public final class SourceOutputStreamFactory
             int length)
         {
             endRO.wrap(buffer, index, index + length);
+            doEnd();
+        }
+
+        private void doEnd()
+        {
             target.removeThrottle(targetId);
             source.removeStream(sourceId);
-            this.streamState = this::afterEnd;
+            this.streamState = this::streamAfterEnd;
         }
 
         private void processUnexpected(
@@ -323,7 +367,7 @@ public final class SourceOutputStreamFactory
 
             source.doReset(streamId);
 
-            this.streamState = this::afterReplyOrReset;
+            this.streamState = this::streamAfterReplyOrReset;
         }
 
         private void handleThrottle(
@@ -335,9 +379,7 @@ public final class SourceOutputStreamFactory
             throttleState.onMessage(msgTypeId, buffer, index, length);
         }
 
-
-
-        private void throttleNextThenSkipWindow(
+        private void throttleBeforeBegin(
             int msgTypeId,
             DirectBuffer buffer,
             int index,
@@ -345,9 +387,6 @@ public final class SourceOutputStreamFactory
         {
             switch (msgTypeId)
             {
-            case WindowFW.TYPE_ID:
-                processNextThenSkipWindow(buffer, index, length);
-                break;
             case ResetFW.TYPE_ID:
                 processReset(buffer, index, length);
                 break;
@@ -357,7 +396,7 @@ public final class SourceOutputStreamFactory
             }
         }
 
-        private void throttleSkipNextWindow(
+        private void throttleBeforeHeadersWritten(
             int msgTypeId,
             DirectBuffer buffer,
             int index,
@@ -366,7 +405,7 @@ public final class SourceOutputStreamFactory
             switch (msgTypeId)
             {
             case WindowFW.TYPE_ID:
-                processSkipNextWindow(buffer, index, length);
+                processWindowToWriteRequestHeaders(buffer, index, length);
                 break;
             case ResetFW.TYPE_ID:
                 processReset(buffer, index, length);
@@ -386,7 +425,7 @@ public final class SourceOutputStreamFactory
             switch (msgTypeId)
             {
             case WindowFW.TYPE_ID:
-                processNextWindow(buffer, index, length);
+                processWindow(buffer, index, length);
                 break;
             case ResetFW.TYPE_ID:
                 processReset(buffer, index, length);
@@ -397,17 +436,40 @@ public final class SourceOutputStreamFactory
             }
         }
 
-        private void processSkipNextWindow(
+        private void processWindowToWriteRequestHeaders(
             DirectBuffer buffer,
             int index,
             int length)
         {
             windowRO.wrap(buffer, index, index + length);
-
-            throttleState = this::throttleNextWindow;
+            int update = windowRO.update();
+            int writableBytes = Math.min(slotPosition - slotOffset, update);
+            MutableDirectBuffer slot = slab.buffer(slotIndex);
+            target.doData(targetId, slot, slotOffset, writableBytes);
+            slotOffset += writableBytes;
+            int bytesDeferred = slotPosition - slotOffset;
+            if (bytesDeferred == 0)
+            {
+                slab.release(slotIndex);
+                slotIndex = NO_SLOT;
+                if (endDeferred)
+                {
+                    doEnd();
+                }
+                else
+                {
+                    streamState = this::streamAfterBeginOrData;
+                    throttleState = this::throttleNextWindow;
+                    update -= writableBytes;
+                    if (update > 0)
+                    {
+                        doWindow(update);
+                    }
+                }
+            }
         }
 
-        private void processNextWindow(
+        private void processWindow(
             DirectBuffer buffer,
             int index,
             int length)
@@ -415,24 +477,13 @@ public final class SourceOutputStreamFactory
             windowRO.wrap(buffer, index, index + length);
 
             final int update = windowRO.update();
-
-            window += update;
-            source.doWindow(sourceId, update);
+            doWindow(update);
         }
 
-        private void processNextThenSkipWindow(
-            DirectBuffer buffer,
-            int index,
-            int length)
+        private void doWindow(int update)
         {
-            windowRO.wrap(buffer, index, index + length);
-
-            final int update = windowRO.update();
-
             window += update;
             source.doWindow(sourceId, update);
-
-            throttleState = this::throttleSkipNextWindow;
         }
 
         private void processReset(
@@ -441,7 +492,7 @@ public final class SourceOutputStreamFactory
             int length)
         {
             resetRO.wrap(buffer, index, index + length);
-
+            slab.release(slotIndex);
             source.doReset(sourceId);
         }
 

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
@@ -80,14 +80,13 @@ public final class SourceOutputStreamFactory
         LongFunction<List<Route>> supplyRoutes,
         LongSupplier supplyTargetId,
         LongObjectBiConsumer<Correlation> correlateNew,
-        int maximumHeadersSize,
-        int memoryForEncode)
+        Slab slab)
     {
         this.source = source;
         this.supplyTargetId = supplyTargetId;
         this.supplyRoutes = supplyRoutes;
         this.correlateNew = correlateNew;
-        this.slab = new Slab(memoryForEncode, maximumHeadersSize);
+        this.slab = slab;
     }
 
     public MessageHandler newStream()

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetInputEstablishedStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetInputEstablishedStreamFactory.java
@@ -67,15 +67,14 @@ public final class TargetInputEstablishedStreamFactory
             Function<String, Target> supplyTarget,
             LongSupplier supplyStreamId,
             LongFunction<Correlation> correlateEstablished,
-            int maximumHeadersSize,
-            int memoryForDecode)
+            Slab slab)
     {
         this.source = source;
         this.supplyTarget = supplyTarget;
         this.supplyStreamId = supplyStreamId;
         this.correlateEstablished = correlateEstablished;
-        this.maximumHeadersSize = maximumHeadersSize;
-        this.slab = new Slab(memoryForDecode, maximumHeadersSize);
+        this.slab = slab;
+        this.maximumHeadersSize = slab.slotCapacity();
     }
 
     public MessageHandler newStream()

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetInputEstablishedStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetInputEstablishedStreamFactory.java
@@ -315,10 +315,7 @@ public final class TargetInputEstablishedStreamFactory
 
             source.removeStream(sourceId);
             target.removeThrottle(targetId);
-            if (slotIndex != NO_SLOT)
-            {
-                slab.release(slotIndex);
-            }
+            slab.release(slotIndex);
         }
 
         private void deferData(
@@ -674,10 +671,7 @@ public final class TargetInputEstablishedStreamFactory
             int length)
         {
             resetRO.wrap(buffer, index, index + length);
-            if (slotIndex != NO_SLOT)
-            {
-                slab.release(slotIndex);
-            }
+            slab.release(slotIndex);
             source.doReset(sourceId);
         }
     }

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetInputEstablishedStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetInputEstablishedStreamFactory.java
@@ -16,7 +16,7 @@
 package org.reaktivity.nukleus.http.internal.routable.stream;
 
 import static java.lang.Integer.parseInt;
-import static org.reaktivity.nukleus.http.internal.routable.stream.Slab.SLOT_NOT_AVAILABLE;
+import static org.reaktivity.nukleus.http.internal.routable.stream.Slab.NO_SLOT;
 import static org.reaktivity.nukleus.http.internal.util.BufferUtil.limitOfBytes;
 
 import java.nio.charset.StandardCharsets;
@@ -88,7 +88,7 @@ public final class TargetInputEstablishedStreamFactory
         private MessageHandler streamState;
         private MessageHandler throttleState;
         private DecoderState decoderState;
-        private int slotIndex = SLOT_NOT_AVAILABLE;
+        private int slotIndex = NO_SLOT;
         private int slotOffset = 0;
         private int slotPosition;
         private boolean endRequested;
@@ -316,7 +316,7 @@ public final class TargetInputEstablishedStreamFactory
 
             source.removeStream(sourceId);
             target.removeThrottle(targetId);
-            if (slotIndex != SLOT_NOT_AVAILABLE)
+            if (slotIndex != NO_SLOT)
             {
                 slab.release(slotIndex);
             }
@@ -633,7 +633,7 @@ public final class TargetInputEstablishedStreamFactory
             if (sourceUpdateDeferred >= 0 && bytesDeferred == 0)
             {
                 slab.release(slotIndex);
-                slotIndex = SLOT_NOT_AVAILABLE;
+                slotIndex = NO_SLOT;
                 if (endRequested)
                 {
                     doEnd();
@@ -675,7 +675,7 @@ public final class TargetInputEstablishedStreamFactory
             int length)
         {
             resetRO.wrap(buffer, index, index + length);
-            if (slotIndex != SLOT_NOT_AVAILABLE)
+            if (slotIndex != NO_SLOT)
             {
                 slab.release(slotIndex);
             }

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetInputEstablishedStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetInputEstablishedStreamFactory.java
@@ -91,7 +91,7 @@ public final class TargetInputEstablishedStreamFactory
         private int slotIndex = NO_SLOT;
         private int slotOffset = 0;
         private int slotPosition;
-        private boolean endRequested;
+        private boolean endDeferred;
 
         private long sourceId;
 
@@ -349,7 +349,7 @@ public final class TargetInputEstablishedStreamFactory
             final long streamId = endRO.streamId();
             assert streamId == sourceId;
 
-            endRequested = true;
+            endDeferred = true;
         }
 
         private int defragmentHttpBegin(
@@ -634,7 +634,7 @@ public final class TargetInputEstablishedStreamFactory
             {
                 slab.release(slotIndex);
                 slotIndex = NO_SLOT;
-                if (endRequested)
+                if (endDeferred)
                 {
                     doEnd();
                 }

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetOutputEstablishedStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetOutputEstablishedStreamFactory.java
@@ -71,14 +71,13 @@ public final class TargetOutputEstablishedStreamFactory
         Function<String, Target> supplyTarget,
         LongSupplier supplyStreamId,
         LongFunction<Correlation> correlateEstablished,
-        int maximumHeadersSize,
-        int memoryForEncode)
+        Slab slab)
     {
         this.source = source;
         this.supplyTarget = supplyTarget;
         this.supplyStreamId = supplyStreamId;
         this.correlateEstablished = correlateEstablished;
-        this.slab = new Slab(memoryForEncode, maximumHeadersSize);
+        this.slab = slab;
     }
 
     public MessageHandler newStream()

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlIT.java
@@ -205,4 +205,41 @@ public class FlowControlIT
         k3po.finish();
     }
 
+    @Test
+    @Specification({
+        "${route}/output/new/controller",
+        "${streams}/request.flow.controlled/client/source",
+        "${streams}/request.flow.controlled/client/target" })
+    public void shouldFlowControlRequest() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.notifyBarrier("ROUTED_INPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/output/new/controller",
+        "${streams}/request.with.content.flow.controlled/client/source",
+        "${streams}/request.with.content.flow.controlled/client/target" })
+    public void shouldFlowControlRequestWithContent() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.notifyBarrier("ROUTED_INPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/output/new/controller",
+        "${streams}/request.headers.too.long/client/source" })
+    public void shouldNotWriteRequestExceedingMaximumHeadersSize() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.finish();
+    }
+
 }

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlIT.java
@@ -166,4 +166,43 @@ public class FlowControlIT
         k3po.finish();
     }
 
+    @Test
+    @Specification({
+        "${route}/output/new/controller",
+        "${streams}/response.with.content.flow.controlled/client/source",
+        "${streams}/response.with.content.flow.controlled/client/target" })
+    public void shouldSplitResponseDataToRespectTargetWindow() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.notifyBarrier("ROUTED_INPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/output/new/controller",
+        "${streams}/response.with.fragmented.content.flow.controlled/client/source",
+        "${streams}/response.with.fragmented.content.flow.controlled/client/target" })
+    public void shouldSlabResponseDataWhenTargetWindowStillNegative() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.notifyBarrier("ROUTED_INPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/output/new/controller",
+        "${streams}/response.with.content.length.and.end.late.target.window/client/source",
+        "${streams}/response.with.content.length.and.end.late.target.window/client/target" })
+    public void shouldWaitForSourceWindowAndWriteDataBeforeProcessingTargetEnd() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.notifyBarrier("ROUTED_INPUT");
+        k3po.finish();
+    }
+
 }

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlIT.java
@@ -231,15 +231,4 @@ public class FlowControlIT
         k3po.finish();
     }
 
-    @Test
-    @Specification({
-        "${route}/output/new/controller",
-        "${streams}/request.headers.too.long/client/source" })
-    public void shouldNotWriteRequestExceedingMaximumHeadersSize() throws Exception
-    {
-        k3po.start();
-        k3po.awaitBarrier("ROUTED_OUTPUT");
-        k3po.finish();
-    }
-
 }

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlLimitsIT.java
@@ -96,6 +96,17 @@ public class FlowControlLimitsIT
 
     @Test
     @Specification({
+        "${route}/output/new/controller",
+        "${streams}/request.headers.too.long/client/source" })
+    public void shouldNotWriteRequestExceedingMaximumHeadersSize() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${route}/input/new/controller",
         "${streams}/request.fragmented.with.content.length/server/source",
         "${streams}/request.fragmented.with.content.length/server/target" })

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/MessageFormatIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/MessageFormatIT.java
@@ -131,7 +131,6 @@ public class MessageFormatIT
     @Specification({
         "${route}/output/new/controller",
         "${streams}/request.with.content.length/client/source",
-
         "${streams}/request.with.content.length/client/target" })
     public void shouldWriteRequestWithContentLength() throws Exception
     {

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/MessageFormatIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/MessageFormatIT.java
@@ -114,4 +114,31 @@ public class MessageFormatIT
         k3po.finish();
     }
 
+    @Test
+    @Specification({
+        "${route}/output/new/controller",
+        "${streams}/request.with.headers/client/source",
+        "${streams}/request.with.headers/client/target" })
+    public void shouldWriteRequestWithHeaders() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.notifyBarrier("ROUTED_INPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/output/new/controller",
+        "${streams}/request.with.content.length/client/source",
+
+        "${streams}/request.with.content.length/client/target" })
+    public void shouldWriteRequestWithContentLength() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.notifyBarrier("ROUTED_INPUT");
+        k3po.finish();
+    }
+
 }


### PR DESCRIPTION
Adds flow control for HTTP Nukleus acting as a client:
- requests going out (source output: must respect target output window)
- responses coming in (target input established: must respect source input window)

Uses a shared Slab per Source (shared across the four stream factories) to reduce memory usage.

Requires PR https://github.com/reaktivity/nukleus-http.spec/pull/14