### PR TITLE
Multiple requests on same input stream, Http server benchmark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <jmh.profilers.version>0.1.3</jmh.profilers.version>
     <nukleus.plugin.version>0.7.3</nukleus.plugin.version>
     <nukleus.version>0.2</nukleus.version>
-    <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
+    <nukleus.http.spec.version>0.14</nukleus.http.spec.version>
     <reaktor.test.version>0.2</reaktor.test.version>
     <reaktor.version>0.1</reaktor.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,8 @@
 
     <junit.version>4.12</junit.version>
     <k3po.version>3.0.0-alpha-63</k3po.version>
-    <jmh.version>1.12</jmh.version>
+    <jmh.version>1.17.4</jmh.version>
+    <jmh.profilers.version>0.1.3</jmh.profilers.version>
     <nukleus.plugin.version>0.7.3</nukleus.plugin.version>
     <nukleus.version>0.2</nukleus.version>
     <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
@@ -111,6 +112,12 @@
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
       <version>${jmh.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.biboudis</groupId>
+      <artifactId>jmh-profilers</artifactId>
+      <version>${jmh.profilers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -233,7 +240,7 @@
                   implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.openjdk.jmh.Main</mainClass>
                   <manifestEntries>
-                    <Class-Path>${project.build.directory}/${project.artifactId}-shaded.jar</Class-Path>
+                    <Class-Path>${project.artifactId}-shaded.jar</Class-Path>
                   </manifestEntries>
                 </transformer>
               </transformers>
@@ -246,6 +253,7 @@
                   <include>net.sf.jopt-simple:jopt-simple</include>
                   <include>org.apache.commons:commons-math3</include>
                   <include>commons-cli:commons-cli</include>
+                  <include>com.github.biboudis:jmh-profilers</include>
                 </includes>
               </artifactSet>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <jmh.version>1.12</jmh.version>
     <nukleus.plugin.version>0.7.3</nukleus.plugin.version>
     <nukleus.version>0.2</nukleus.version>
-    <nukleus.http.spec.version>0.13</nukleus.http.spec.version>
+    <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
     <reaktor.test.version>0.2</reaktor.test.version>
     <reaktor.version>0.1</reaktor.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/Correlation.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/Correlation.java
@@ -21,20 +21,31 @@ import java.util.Objects;
 
 import org.reaktivity.nukleus.http.internal.router.RouteKind;
 
-public class Correlation
+public class Correlation<S>
 {
     private final String source;
     private final long id;
     private final RouteKind established;
+    private final S state;
 
     public Correlation(
         long id,
         String source,
-        RouteKind established)
+        RouteKind established,
+        S state)
     {
         this.id = id;
         this.source = requireNonNull(source, "source");
         this.established = requireNonNull(established, "established");
+        this.state = state;
+    }
+
+    public Correlation(
+            long id,
+            String source,
+            RouteKind established)
+    {
+        this(id, source, established, null);
     }
 
     public String source()
@@ -50,6 +61,11 @@ public class Correlation
     public RouteKind established()
     {
         return established;
+    }
+
+    public S state()
+    {
+        return state;
     }
 
     @Override
@@ -71,10 +87,11 @@ public class Correlation
             return false;
         }
 
-        Correlation that = (Correlation) obj;
+        Correlation<?> that = (Correlation<?>) obj;
         return this.id == that.id &&
                 this.established == that.established &&
-                Objects.equals(this.source, that.source);
+                Objects.equals(this.source, that.source) &&
+                Objects.equals(this.state, that.state);
     }
 
     @Override

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/Routable.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/Routable.java
@@ -53,18 +53,18 @@ public final class Routable extends Nukleus.Composite
     private final Map<String, Source> sourcesByPartitionName;
     private final Map<String, Target> targetsByName;
     private final Long2ObjectHashMap<List<Route>> routesByRef;
-    private final LongObjectBiConsumer<Correlation> correlateNew;
-    private final LongFunction<Correlation> correlateEstablished;
-    private final LongFunction<Correlation> lookupEstablished;
+    private final LongObjectBiConsumer<Correlation<?>> correlateNew;
+    private final LongFunction<Correlation<?>> correlateEstablished;
+    private final LongFunction<Correlation<?>> lookupEstablished;
     private final LongSupplier supplyTargetId;
 
     public Routable(
         Context context,
         Conductor conductor,
         String sourceName,
-        LongObjectBiConsumer<Correlation> correlateNew,
-        LongFunction<Correlation> correlateEstablished,
-        LongFunction<Correlation> lookupEstablished)
+        LongObjectBiConsumer<Correlation<?>> correlateNew,
+        LongFunction<Correlation<?>> correlateEstablished,
+        LongFunction<Correlation<?>> lookupEstablished)
     {
         this.context = context;
         this.conductor = conductor;

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/Target.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/Target.java
@@ -90,7 +90,7 @@ public final class Target implements Nukleus
         return name;
     }
 
-    public void addThrottle(
+    public void setThrottle(
         long streamId,
         MessageHandler throttle)
     {

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/OutputEstablishedState.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/OutputEstablishedState.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.http.internal.routable.stream;
+
+import java.util.function.Function;
+
+import org.reaktivity.nukleus.http.internal.routable.Target;
+
+final class OutputEstablishedState
+{
+    final long streamId;
+    String target;
+    int window;
+    boolean started;
+    int pendingRequests;
+    public boolean endRequested;
+
+    OutputEstablishedState(long streamId, String target)
+    {
+        this.streamId = streamId;
+        this.target = target;
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("[streamId=%016x, window=%d]",
+                getClass().getSimpleName(), streamId, window);
+    }
+
+    public void doEnd(Function<String, Target> supplyTarget)
+    {
+        if (pendingRequests == 0)
+        {
+            Target transportOutput = supplyTarget.apply(target);
+            transportOutput.doEnd(streamId);
+            // TODO: call a callback registered by TargetOutputEstablishedStream so it can clean up resources
+        }
+        else
+        {
+            endRequested = true;
+        }
+    }
+}
+

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/ServerConnectionState.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/ServerConnectionState.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
 
 import org.reaktivity.nukleus.http.internal.routable.Target;
 
-final class OutputEstablishedState
+final class ServerConnectionState
 {
     final long streamId;
     String target;
@@ -28,7 +28,7 @@ final class OutputEstablishedState
     int pendingRequests;
     public boolean endRequested;
 
-    OutputEstablishedState(long streamId, String target)
+    ServerConnectionState(long streamId, String target)
     {
         this.streamId = streamId;
         this.target = target;

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
@@ -117,7 +117,7 @@ public final class SourceInputStreamFactory
         private int contentRemaining;
         private int availableTargetWindow;
         private boolean hasUpgrade;
-        private Correlation<OutputEstablishedState> correlation;
+        private Correlation<ServerConnectionState> correlation;
 
         @Override
         public String toString()
@@ -528,9 +528,9 @@ public final class SourceInputStreamFactory
                         if (correlation == null)
                         {
                             long newOutputEstablishedStreamId = supplyStreamId.getAsLong();
-                            OutputEstablishedState state = new OutputEstablishedState(newOutputEstablishedStreamId,
+                            ServerConnectionState state = new ServerConnectionState(newOutputEstablishedStreamId,
                                     newTarget.name());
-                            this.correlation = new Correlation<OutputEstablishedState>(sourceCorrelationId, source.routableName(),
+                            this.correlation = new Correlation<ServerConnectionState>(sourceCorrelationId, source.routableName(),
                                     OUTPUT_ESTABLISHED, state);
                         }
                         else

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
@@ -246,7 +246,7 @@ public final class SourceOutputStreamFactory
                 target = route.target();
                 final long targetRef = route.targetRef();
                 target.doBegin(targetId, targetRef, targetCorrelationId);
-                target.addThrottle(targetId, this::handleThrottle);
+                target.setThrottle(targetId, this::handleThrottle);
 
                 String[] pseudoHeaders = new String[4];
 

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
@@ -79,13 +79,13 @@ public final class SourceOutputStreamFactory
         Source source,
         LongFunction<List<Route>> supplyRoutes,
         LongSupplier supplyTargetId,
-        LongObjectBiConsumer<Correlation<?>> correlateNew2,
+        LongObjectBiConsumer<Correlation<?>> correlateNew,
         Slab slab)
     {
         this.source = source;
         this.supplyTargetId = supplyTargetId;
         this.supplyRoutes = supplyRoutes;
-        this.correlateNew = correlateNew2;
+        this.correlateNew = correlateNew;
         this.slab = slab;
     }
 

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
@@ -71,7 +71,7 @@ public final class SourceOutputStreamFactory
     private final Source source;
     private final LongSupplier supplyTargetId;
     private final LongFunction<List<Route>> supplyRoutes;
-    private final LongObjectBiConsumer<Correlation> correlateNew;
+    private final LongObjectBiConsumer<Correlation<?>> correlateNew;
 
     private final Slab slab;
 
@@ -79,13 +79,13 @@ public final class SourceOutputStreamFactory
         Source source,
         LongFunction<List<Route>> supplyRoutes,
         LongSupplier supplyTargetId,
-        LongObjectBiConsumer<Correlation> correlateNew,
+        LongObjectBiConsumer<Correlation<?>> correlateNew2,
         Slab slab)
     {
         this.source = source;
         this.supplyTargetId = supplyTargetId;
         this.supplyRoutes = supplyRoutes;
-        this.correlateNew = correlateNew;
+        this.correlateNew = correlateNew2;
         this.slab = slab;
     }
 
@@ -238,7 +238,8 @@ public final class SourceOutputStreamFactory
             {
                 targetId = supplyTargetId.getAsLong();
                 final long targetCorrelationId = targetId;
-                final Correlation correlation = new Correlation(correlationId, source.routableName(), INPUT_ESTABLISHED);
+                final Correlation<?> correlation =
+                        new Correlation<Object>(correlationId, source.routableName(), INPUT_ESTABLISHED);
 
                 correlateNew.accept(targetCorrelationId, correlation);
 

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetInputEstablishedStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetInputEstablishedStreamFactory.java
@@ -58,7 +58,7 @@ public final class TargetInputEstablishedStreamFactory
     private final Source source;
     private final Function<String, Target> supplyTarget;
     private final LongSupplier supplyStreamId;
-    private final LongFunction<Correlation> correlateEstablished;
+    private final LongFunction<Correlation<?>> correlateEstablished;
     private final int maximumHeadersSize;
     private final Slab slab;
 
@@ -66,13 +66,13 @@ public final class TargetInputEstablishedStreamFactory
             Source source,
             Function<String, Target> supplyTarget,
             LongSupplier supplyStreamId,
-            LongFunction<Correlation> correlateEstablished,
+            LongFunction<Correlation<?>> correlateEstablished2,
             Slab slab)
     {
         this.source = source;
         this.supplyTarget = supplyTarget;
         this.supplyStreamId = supplyStreamId;
-        this.correlateEstablished = correlateEstablished;
+        this.correlateEstablished = correlateEstablished2;
         this.slab = slab;
         this.maximumHeadersSize = slab.slotCapacity();
     }
@@ -243,7 +243,7 @@ public final class TargetInputEstablishedStreamFactory
             final long sourceRef = beginRO.referenceId();
             final long targetCorrelationId = beginRO.correlationId();
 
-            final Correlation correlation = correlateEstablished.apply(targetCorrelationId);
+            final Correlation<?> correlation = correlateEstablished.apply(targetCorrelationId);
 
             if (sourceRef == 0L && correlation != null)
             {

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetInputEstablishedStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetInputEstablishedStreamFactory.java
@@ -447,7 +447,7 @@ public final class TargetInputEstablishedStreamFactory
 
                 target.doHttpBegin(targetId, 0L, sourceCorrelationId,
                         hs -> headers.forEach((k, v) -> hs.item(i -> i.name(k).value(v))));
-                target.addThrottle(targetId, this::handleThrottle);
+                target.setThrottle(targetId, this::handleThrottle);
 
                 boolean hasUpgrade = headers.containsKey("upgrade");
 

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetOutputEstablishedStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetOutputEstablishedStreamFactory.java
@@ -89,7 +89,7 @@ public final class TargetOutputEstablishedStreamFactory
         private long sourceId;
 
         private Target target;
-        private OutputEstablishedState targetStream;
+        private ServerConnectionState targetStream;
 
         private int slotIndex;
         private int slotPosition;
@@ -218,8 +218,8 @@ public final class TargetOutputEstablishedStreamFactory
             final OctetsFW extension = beginRO.extension();
 
             @SuppressWarnings("unchecked")
-            final Correlation<OutputEstablishedState> correlation =
-                         (Correlation<OutputEstablishedState>) correlateEstablished.apply(targetCorrelationId);
+            final Correlation<ServerConnectionState> correlation =
+                         (Correlation<ServerConnectionState>) correlateEstablished.apply(targetCorrelationId);
 
             if (sourceRef == 0L && correlation != null)
             {

--- a/src/main/java/org/reaktivity/nukleus/http/internal/router/Router.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/router/Router.java
@@ -39,7 +39,7 @@ public final class Router extends Nukleus.Composite
 
     private final Context context;
     private final Map<String, Routable> routables;
-    private final Long2ObjectHashMap<Correlation> correlations;
+    private final Long2ObjectHashMap<Correlation<?>> correlations;
     private final AtomicCounter routesSourced;
 
     private Conductor conductor;

--- a/src/test/java/org/reaktivity/nukleus/http/internal/bench/HttpServerBM.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/bench/HttpServerBM.java
@@ -15,12 +15,14 @@
  */
 package org.reaktivity.nukleus.http.internal.bench;
 
+import static java.lang.String.format;
 import static java.nio.ByteBuffer.allocateDirect;
 import static java.nio.file.FileVisitOption.FOLLOW_LINKS;
 import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.agrona.BitUtil.SIZE_OF_INT;
 import static org.agrona.BitUtil.SIZE_OF_LONG;
+import static org.agrona.IoUtil.ensureDirectoryExists;
 import static org.reaktivity.nukleus.Configuration.DIRECTORY_PROPERTY_NAME;
 import static org.reaktivity.nukleus.Configuration.STREAMS_BUFFER_CAPACITY_PROPERTY_NAME;
 
@@ -51,7 +53,6 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.infra.Control;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -61,193 +62,283 @@ import org.reaktivity.nukleus.http.internal.HttpController;
 import org.reaktivity.nukleus.http.internal.HttpStreams;
 import org.reaktivity.nukleus.http.internal.types.stream.BeginFW;
 import org.reaktivity.nukleus.http.internal.types.stream.DataFW;
+import org.reaktivity.nukleus.http.internal.types.stream.ResetFW;
 import org.reaktivity.nukleus.http.internal.types.stream.WindowFW;
 import org.reaktivity.reaktor.internal.Reaktor;
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
 @Fork(3)
-@Warmup(iterations = 5, time = 1, timeUnit = SECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = SECONDS)
+@Warmup(iterations = 1, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = SECONDS)
 @OutputTimeUnit(SECONDS)
 public class HttpServerBM
 {
-    private final Configuration configuration;
-    private final Reaktor reaktor;
-
+    @State(Scope.Group)
+    public static class GroupState
     {
-        Properties properties = new Properties();
-        properties.setProperty(DIRECTORY_PROPERTY_NAME, "target/nukleus-benchmarks");
-        properties.setProperty(STREAMS_BUFFER_CAPACITY_PROPERTY_NAME, Long.toString(1024L * 1024L * 16L));
+        private final Configuration configuration;
+        private final Reaktor reaktor;
 
-        configuration = new Configuration(properties);
-
-        try
         {
-            Files.walk(configuration.directory(), FOLLOW_LINKS)
-                 .map(Path::toFile)
-                 .forEach(File::delete);
+            System.out.println(format("HttpServerBM.GroupState<init>: thread %s instance %s", Thread.currentThread(), this));
+            Properties properties = new Properties();
+            properties.setProperty(DIRECTORY_PROPERTY_NAME, "target/nukleus-benchmarks");
+            properties.setProperty(STREAMS_BUFFER_CAPACITY_PROPERTY_NAME, Long.toString(1024L * 1024L * 16L));
+
+            configuration = new Configuration(properties);
+            ensureDirectoryExists(configuration.directory().toFile(), configuration.directory().toString());
+
+            try
+            {
+                Files.walk(configuration.directory(), FOLLOW_LINKS)
+                     .map(Path::toFile)
+                     .forEach(File::delete);
+            }
+            catch (IOException ex)
+            {
+                LangUtil.rethrowUnchecked(ex);
+            }
+
+            reaktor = Reaktor.launch(configuration, n -> "http".equals(n), HttpController.class::isAssignableFrom);
         }
-        catch (IOException ex)
+
+        private final BeginFW beginRO = new BeginFW();
+        private final DataFW dataRO = new DataFW();
+        private final WindowFW windowRO = new WindowFW();
+
+        private final BeginFW.Builder beginRW = new BeginFW.Builder();
+        private final DataFW.Builder dataRW = new DataFW.Builder();
+        private final WindowFW.Builder windowRW = new WindowFW.Builder();
+
+        private HttpStreams sourceInputStreams;
+        private HttpStreams sourceOutputEstStreams;
+
+        private MutableDirectBuffer throttleBuffer;
+
+        private long sourceInputRef;
+
+        private long sourceInputId;
+        private DataFW data;
+
+        private MessageHandler sourceOutputEstHandler;
+        int availableSourceInputWindow = 0;
+
+        @Setup(Level.Trial)
+        public void reinit() throws Exception
         {
-            LangUtil.rethrowUnchecked(ex);
+            System.out.println(format("HttpServerBM.GroupState.reInit(): thread %s instance %s", Thread.currentThread(), this));
+            final Random random = new Random();
+            final HttpController controller = reaktor.controller(HttpController.class);
+
+            this.sourceInputRef = controller.routeInputNew("source", 0L, "http", 0L, emptyMap()).get();
+
+            this.sourceInputStreams = controller.streams("source");
+
+            this.sourceInputId = random.nextLong();
+            this.sourceOutputEstHandler = this::processBegin;
+
+            final AtomicBuffer writeBuffer = new UnsafeBuffer(new byte[256]);
+
+            BeginFW begin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+                    .streamId(sourceInputId)
+                    .referenceId(sourceInputRef)
+                    .correlationId(random.nextLong())
+                    .extension(e -> e.reset())
+                    .build();
+
+            this.sourceInputStreams.writeStreams(begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof());
+
+            String payload =
+                    "POST / HTTP/1.1\r\n" +
+                    "Host: localhost:8080\r\n" +
+                    "Content-Length:12\r\n" +
+                    "\r\n" +
+                    "Hello, world";
+            byte[] sendArray = payload.getBytes(StandardCharsets.UTF_8);
+
+            this.data = dataRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+                              .streamId(sourceInputId)
+                              .payload(p -> p.set(sendArray))
+                              .extension(e -> e.reset())
+                              .build();
+
+            this.throttleBuffer = new UnsafeBuffer(allocateDirect(SIZE_OF_LONG + SIZE_OF_INT));
+
+            boolean writeSucceeded = false;
+            for (int i=0; i < 100 && !writeSucceeded; i++)
+            {
+                Thread.sleep(100);
+                writeSucceeded = write();
+            }
+
+            if (writeSucceeded)
+            {
+                for (int i=0; i < 100 && sourceOutputEstStreams == null; i++)
+                {
+                    try
+                    {
+                        sourceOutputEstStreams = controller.streams("http", "source");
+                    }
+                    catch (IllegalStateException e)
+                    {
+                        Thread.sleep(100);
+                    }
+                }
+                int result = read();
+                System.out.println("reinit(): result: " + result);
+            }
+            else
+            {
+                throw new RuntimeException("write() failed");
+            }
+
         }
 
-        reaktor = Reaktor.launch(configuration, n -> "http".equals(n), HttpController.class::isAssignableFrom);
-    }
+        @TearDown(Level.Trial)
+        public void reset() throws Exception
+        {
+            HttpController controller = reaktor.controller(HttpController.class);
 
-    private final BeginFW beginRO = new BeginFW();
-    private final DataFW dataRO = new DataFW();
+            controller.unrouteInputNew("source", sourceInputRef, "http", 0L, null).get();
 
-    private final BeginFW.Builder beginRW = new BeginFW.Builder();
-    private final DataFW.Builder dataRW = new DataFW.Builder();
-    private final WindowFW.Builder windowRW = new WindowFW.Builder();
+            this.sourceInputStreams.close();
+            this.sourceInputStreams = null;
 
-    private HttpStreams sourceInputStreams;
-    private HttpStreams sourceOutputEstStreams;
+            this.sourceOutputEstStreams.close();
+            this.sourceOutputEstStreams = null;
+        }
 
-    private MutableDirectBuffer throttleBuffer;
+        private int read()
+        {
+            return sourceOutputEstStreams.readStreams(this::handleSourceOutputEst);
+        }
 
-    private long sourceInputRef;
-    private long targetInputRef;
+        private boolean write()
+        {
+            try
+            {
+                Thread.sleep(10);
+            }
+            catch (InterruptedException e)
+            {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+            sourceInputStreams.readThrottle(this::sourceInputThrottle);
+            boolean result = availableSourceInputWindow >= data.length();
+            if (result)
+            {
+                result = sourceInputStreams.writeStreams(data.typeId(), data.buffer(), 0, data.limit());
+                if (result)
+                {
+                    availableSourceInputWindow -= data.length();
+                    System.out.println(format("write: %d bytes written", data.length()));
+                }
+                else
+                {
+                    System.out.println(format("write failed, availableSourceInputWindow = %d", availableSourceInputWindow));
+                }
+            }
+            return result;
+        }
 
-    private long sourceInputId;
-    private DataFW data;
+        private void sourceInputThrottle(
+            int msgTypeId,
+            MutableDirectBuffer buffer,
+            int index,
+            int length)
+        {
+            switch (msgTypeId)
+            {
+            case WindowFW.TYPE_ID:
+                windowRO.wrap(buffer, index, index + length);
+                availableSourceInputWindow += windowRO.update();
+                System.out.println(format("sourceInputThrottle: received window update %d, availableSourceInputWindow=%d",
+                        windowRO.update(), availableSourceInputWindow));
+                break;
+            case ResetFW.TYPE_ID:
+                System.out.println("ERROR: reset detected in sourceInputThrottle");
+                break;
+            default:
+                System.out.println(format("ERROR: unexpected msgTypeId %d detected in sourceInputThrottle",
+                        msgTypeId));
+                break;
+            }
+        }
 
-    private MessageHandler sourceOutputEstHandler;
+        private void handleSourceOutputEst(
+            int msgTypeId,
+            MutableDirectBuffer buffer,
+            int index,
+            int length)
+        {
+            sourceOutputEstHandler.onMessage(msgTypeId, buffer, index, length);
+        }
 
-    @Setup(Level.Trial)
-    public void reinit() throws Exception
-    {
-        final Random random = new Random();
-        final HttpController controller = reaktor.controller(HttpController.class);
+        private void processBegin(
+            int msgTypeId,
+            MutableDirectBuffer buffer,
+            int index,
+            int length)
+        {
+            beginRO.wrap(buffer, index, index + length);
+            System.out.println("processBegin: " +  beginRO);
+            final long streamId = beginRO.streamId();
+            doWindow(streamId, 8192);
 
-        this.targetInputRef = random.nextLong();
-        this.sourceInputRef = controller.routeInputNew("source", 0L, "target", targetInputRef, emptyMap()).get();
+            this.sourceOutputEstHandler = this::processData;
+        }
 
-        this.sourceInputStreams = controller.streams("source");
-        this.sourceOutputEstStreams = controller.streams("http", "target");
+        private void processData(
+            int msgTypeId,
+            MutableDirectBuffer buffer,
+            int index,
+            int length)
+        {
+            dataRO.wrap(buffer, index, index + length);
+            System.out.println("processData: " +  dataRO);
+            final long streamId = dataRO.streamId();
+            final int update = dataRO.length();
+            doWindow(streamId, update);
+        }
 
-        this.sourceInputId = random.nextLong();
-        this.sourceOutputEstHandler = this::processBegin;
-
-        final AtomicBuffer writeBuffer = new UnsafeBuffer(new byte[256]);
-
-        BeginFW begin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
-                .streamId(sourceInputId)
-                .referenceId(sourceInputRef)
-                .correlationId(random.nextLong())
-                .extension(e -> e.reset())
-                .build();
-
-        this.sourceInputStreams.writeStreams(begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof());
-
-        String payload =
-                "POST / HTTP/1.1\r\n" +
-                "Host: localhost:8080\r\n" +
-                "Content-Length:12\r\n" +
-                "\r\n" +
-                "Hello, world";
-        byte[] sendArray = payload.getBytes(StandardCharsets.UTF_8);
-
-        this.data = dataRW.wrap(writeBuffer, 0, writeBuffer.capacity())
-                          .streamId(sourceInputId)
-                          .payload(p -> p.set(sendArray))
-                          .extension(e -> e.reset())
-                          .build();
-
-        this.throttleBuffer = new UnsafeBuffer(allocateDirect(SIZE_OF_LONG + SIZE_OF_INT));
-    }
-
-    @TearDown(Level.Trial)
-    public void reset() throws Exception
-    {
-        HttpController controller = reaktor.controller(HttpController.class);
-
-        controller.unrouteInputNew("source", sourceInputRef, "target", targetInputRef, null).get();
-
-        this.sourceInputStreams.close();
-        this.sourceInputStreams = null;
-
-        this.sourceOutputEstStreams.close();
-        this.sourceOutputEstStreams = null;
+        private void doWindow(
+            final long streamId,
+            final int update)
+        {
+            final WindowFW window = windowRW.wrap(throttleBuffer, 0, throttleBuffer.capacity())
+                    .streamId(streamId)
+                    .update(update)
+                    .build();
+            System.out.println(format("Offering window: %d", update));
+            sourceOutputEstStreams.writeThrottle(window.typeId(), window.buffer(), window.offset(), window.sizeof());
+        }
     }
 
     @Benchmark
     @Group("throughput")
     @GroupThreads(1)
-    public void writer(Control control) throws Exception
+    public int writer(final GroupState state) throws Exception
     {
-        while (!control.stopMeasurement &&
-               !sourceInputStreams.writeStreams(data.typeId(), data.buffer(), 0, data.limit()))
+        while (!state.write())
         {
             Thread.yield();
         }
-
-        while (!control.stopMeasurement &&
-                sourceInputStreams.readThrottle((t, b, o, l) -> {}) == 0)
-        {
-            Thread.yield();
-        }
+        return 1;
     }
 
     @Benchmark
     @Group("throughput")
     @GroupThreads(1)
-    public void reader(Control control) throws Exception
+    public int reader(final GroupState state) throws Exception
     {
-        while (!control.stopMeasurement &&
-               sourceOutputEstStreams.readStreams(this::handleSourceOutputEst) == 0)
+        int result;
+        while ((result = state.read()) == 0)
         {
             Thread.yield();
         }
-    }
-
-    private void handleSourceOutputEst(
-        int msgTypeId,
-        MutableDirectBuffer buffer,
-        int index,
-        int length)
-    {
-        sourceOutputEstHandler.onMessage(msgTypeId, buffer, index, length);
-    }
-
-    private void processBegin(
-        int msgTypeId,
-        MutableDirectBuffer buffer,
-        int index,
-        int length)
-    {
-        beginRO.wrap(buffer, index, index + length);
-        final long streamId = beginRO.streamId();
-        doWindow(streamId, 8192);
-
-        this.sourceOutputEstHandler = this::processData;
-    }
-
-    private void processData(
-        int msgTypeId,
-        MutableDirectBuffer buffer,
-        int index,
-        int length)
-    {
-        dataRO.wrap(buffer, index, index + length);
-        final long streamId = dataRO.streamId();
-        final int update = dataRO.length();
-
-        doWindow(streamId, update);
-    }
-
-    private void doWindow(
-        final long streamId,
-        final int update)
-    {
-        final WindowFW window = windowRW.wrap(throttleBuffer, 0, throttleBuffer.capacity())
-                .streamId(streamId)
-                .update(update)
-                .build();
-
-        sourceOutputEstStreams.writeThrottle(window.typeId(), window.buffer(), window.offset(), window.sizeof());
+        return result;
     }
 
     public static void main(String[] args) throws RunnerException
@@ -255,6 +346,9 @@ public class HttpServerBM
         Options opt = new OptionsBuilder()
                 .include(HttpServerBM.class.getSimpleName())
                 .forks(0)
+                .threads(1)
+                .warmupIterations(0)
+                .measurementIterations(1)
                 .build();
 
         new Runner(opt).run();

--- a/src/test/java/org/reaktivity/nukleus/http/internal/bench/HttpServerBM.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/bench/HttpServerBM.java
@@ -249,8 +249,6 @@ public class HttpServerBM
             case WindowFW.TYPE_ID:
                 windowRO.wrap(buffer, index, index + length);
                 availableSourceInputWindow += windowRO.update();
-//                System.out.println(format("sourceInputThrottle: received window update %d, availableSourceInputWindow=%d",
-//                        windowRO.update(), availableSourceInputWindow));
                 break;
             case ResetFW.TYPE_ID:
                 System.out.println("ERROR: reset detected in sourceInputThrottle");

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/ConnectionManagementIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/ConnectionManagementIT.java
@@ -74,4 +74,17 @@ public class ConnectionManagementIT
         k3po.notifyBarrier("ROUTED_INPUT");
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
+        "${streams}/multiple.requests/server/source",
+        "${streams}/multiple.requests/server/target" })
+    public void shouldAcceptMultipleRequests() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_INPUT");
+        k3po.notifyBarrier("ROUTED_OUTPUT");
+        k3po.finish();
+    }
 }

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/ConnectionManagementIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/ConnectionManagementIT.java
@@ -64,6 +64,19 @@ public class ConnectionManagementIT
 
     @Test
     @Specification({
+        "${route}/input/new/controller",
+        "${streams}/multiple.requests/server/source",
+        "${streams}/multiple.requests/server/target" })
+    public void shouldAcceptMultipleRequests() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_INPUT");
+        k3po.notifyBarrier("ROUTED_OUTPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${route}/output/new/controller",
         "${streams}/response.status.101.with.upgrade/client/source",
         "${streams}/response.status.101.with.upgrade/client/target" })
@@ -77,14 +90,14 @@ public class ConnectionManagementIT
 
     @Test
     @Specification({
-        "${route}/input/new/controller",
-        "${streams}/multiple.requests/server/source",
-        "${streams}/multiple.requests/server/target" })
-    public void shouldAcceptMultipleRequests() throws Exception
+        "${route}/output/new/controller",
+        "${streams}/multiple.requests/client/source",
+        "${streams}/multiple.requests/client/target" })
+    public void shouldAcceptMultipleRequestsClient() throws Exception
     {
         k3po.start();
-        k3po.awaitBarrier("ROUTED_INPUT");
-        k3po.notifyBarrier("ROUTED_OUTPUT");
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.notifyBarrier("ROUTED_INPUT");
         k3po.finish();
     }
 }

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/ConnectionManagementIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/ConnectionManagementIT.java
@@ -87,17 +87,4 @@ public class ConnectionManagementIT
         k3po.notifyBarrier("ROUTED_INPUT");
         k3po.finish();
     }
-
-    @Test
-    @Specification({
-        "${route}/output/new/controller",
-        "${streams}/multiple.requests/client/source",
-        "${streams}/multiple.requests/client/target" })
-    public void shouldAcceptMultipleRequestsClient() throws Exception
-    {
-        k3po.start();
-        k3po.awaitBarrier("ROUTED_OUTPUT");
-        k3po.notifyBarrier("ROUTED_INPUT");
-        k3po.finish();
-    }
 }

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlAfterUpgradeIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlAfterUpgradeIT.java
@@ -64,7 +64,21 @@ public class FlowControlAfterUpgradeIT
         "${streams}/request.with.upgrade.and.data/server/source",
         "${streams}/request.with.upgrade.and.data/server/target" })
     @ScriptProperty("targetInputInitialWindow [0x80 0x00 0x00 0x00]") // 128 bytes, same as max headers size
-    public void shouldFlowControlDataAfterUpgradeAndAlignWindows() throws Exception
+    public void shouldFlowControlRequestDataAfterUpgrade() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_INPUT");
+        k3po.notifyBarrier("ROUTED_OUTPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
+        "${streams}/response.with.upgrade.and.data/server/source",
+        "${streams}/response.with.upgrade.and.data/server/target" })
+    @ScriptProperty("sourceOutputInitialWindow [0x80 0x00 0x00 0x00]") // 128 bytes, same as max headers size
+    public void shouldFlowControlResponseDataAfterUpgrade() throws Exception
     {
         k3po.start();
         k3po.awaitBarrier("ROUTED_INPUT");

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlAfterUpgradeIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlAfterUpgradeIT.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.http.internal.streams.rfc7230;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+import static org.reaktivity.nukleus.http.internal.Context.MAXIMUM_HEADERS_SIZE_PROPERTY_NAME;
+import static org.reaktivity.nukleus.http.internal.Context.MEMORY_FOR_DECODE_PROPERTY_NAME;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.k3po.junit.annotation.ScriptProperty;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.reaktivity.nukleus.http.internal.test.SystemPropertiesRule;
+import org.reaktivity.reaktor.test.NukleusRule;
+
+public class FlowControlAfterUpgradeIT
+{
+    private final K3poRule k3po = new K3poRule()
+            .addScriptRoot("route", "org/reaktivity/specification/nukleus/http/control/route")
+            .addScriptRoot("streams", "org/reaktivity/specification/nukleus/http/streams/rfc7230/flow.control");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
+
+    private final TestRule properties = new SystemPropertiesRule()
+        .setProperty(MAXIMUM_HEADERS_SIZE_PROPERTY_NAME, "128")
+        .setProperty(MEMORY_FOR_DECODE_PROPERTY_NAME, "128");
+
+    private final NukleusRule nukleus = new NukleusRule("http")
+        .directory("target/nukleus-itests")
+        .commandBufferCapacity(1024)
+        .responseBufferCapacity(1024)
+        .counterValuesBufferCapacity(1024)
+        .streams("http", "source")
+        .streams("source", "http#source")
+        .streams("target", "http#source")
+        .streams("http", "target")
+        .streams("source", "http#target");
+
+    @Rule
+    public final TestRule chain = outerRule(properties).around(nukleus).around(k3po).around(timeout);
+
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
+        "${streams}/request.with.upgrade.and.data/server/source",
+        "${streams}/request.with.upgrade.and.data/server/target" })
+    @ScriptProperty("targetInputInitialWindow [0x80 0x00 0x00 0x00]") // 128 bytes, same as max headers size
+    public void shouldFlowControlDataAfterUpgradeAndAlignWindows() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_INPUT");
+        k3po.notifyBarrier("ROUTED_OUTPUT");
+        k3po.finish();
+    }
+}
+

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlIT.java
@@ -181,6 +181,19 @@ public class FlowControlIT
 
     @Test
     @Specification({
+        "${route}/input/new/controller",
+        "${streams}/multiple.requests.with.response.flow.control/server/source",
+        "${streams}/multiple.requests.with.response.flow.control/server/target" })
+    public void shouldFlowControlMultipleResponses() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_INPUT");
+        k3po.notifyBarrier("ROUTED_OUTPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${route}/output/new/controller",
         "${streams}/response.fragmented/client/source",
         "${streams}/response.fragmented/client/target" })

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlIT.java
@@ -143,8 +143,8 @@ public class FlowControlIT
     @Test
     @Specification({
         "${route}/input/new/controller",
-        "${streams}/multiple.requests.combined/server/source",
-        "${streams}/multiple.requests.combined/server/target" })
+        "${streams}/multiple.requests.pipelined/server/source",
+        "${streams}/multiple.requests.pipelined/server/target" })
     public void shouldAcceptMultipleRequestsInSameDataFrame() throws Exception
     {
         k3po.start();
@@ -156,8 +156,8 @@ public class FlowControlIT
     @Test
     @Specification({
         "${route}/input/new/controller",
-        "${streams}/multiple.requests.combined.fragmented/server/source",
-        "${streams}/multiple.requests.combined.fragmented/server/target" })
+        "${streams}/multiple.requests.pipelined.fragmented/server/source",
+        "${streams}/multiple.requests.pipelined.fragmented/server/target" })
     public void shouldAcceptMultipleRequestsInSameDataFrameFragmented() throws Exception
     {
         k3po.start();
@@ -169,9 +169,9 @@ public class FlowControlIT
     @Test
     @Specification({
         "${route}/input/new/controller",
-        "${streams}/multiple.requests.with.content.length.combined.fragmented/server/source",
-        "${streams}/multiple.requests.with.content.length.combined.fragmented/server/target" })
-    public void shouldAcceptMultipleRequestsWithContentLengthCombinedFragmented() throws Exception
+        "${streams}/multiple.requests.with.content.length.pipelined.fragmented/server/source",
+        "${streams}/multiple.requests.with.content.length.pipelined.fragmented/server/target" })
+    public void shouldAcceptMultipleRequestsWithContentLengthPipelinedFragmented() throws Exception
     {
         k3po.start();
         k3po.awaitBarrier("ROUTED_INPUT");

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlIT.java
@@ -142,6 +142,45 @@ public class FlowControlIT
 
     @Test
     @Specification({
+        "${route}/input/new/controller",
+        "${streams}/multiple.requests.combined/server/source",
+        "${streams}/multiple.requests.combined/server/target" })
+    public void shouldAcceptMultipleRequestsInSameDataFrame() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_INPUT");
+        k3po.notifyBarrier("ROUTED_OUTPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
+        "${streams}/multiple.requests.combined.fragmented/server/source",
+        "${streams}/multiple.requests.combined.fragmented/server/target" })
+    public void shouldAcceptMultipleRequestsInSameDataFrameFragmented() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_INPUT");
+        k3po.notifyBarrier("ROUTED_OUTPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
+        "${streams}/multiple.requests.with.content.length.combined.fragmented/server/source",
+        "${streams}/multiple.requests.with.content.length.combined.fragmented/server/target" })
+    public void shouldAcceptMultipleRequestsWithContentLengthCombinedFragmented() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_INPUT");
+        k3po.notifyBarrier("ROUTED_OUTPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${route}/output/new/controller",
         "${streams}/response.fragmented/client/source",
         "${streams}/response.fragmented/client/target" })

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/FlowControlLimitsIT.java
@@ -119,6 +119,7 @@ public class FlowControlLimitsIT
         k3po.finish();
     }
 
+
     @Test
     @Specification({
         "${route}/output/new/controller",


### PR DESCRIPTION
- added support for multiple requests coming in on the same source input stream (but not including ordering of responses if the requests got routed to different targets). 
- fixed several bugs involving flow control
- got HttpServerBM working