### PR TITLE
Multiple requests client, client benchmark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <checkstyle.suppressions.location>src/conf/checkstyle/suppressions.xml</checkstyle.suppressions.location>
 
     <junit.version>4.12</junit.version>
-    <k3po.version>3.0.0-alpha-63</k3po.version>
+    <k3po.version>develop-SNAPSHOT</k3po.version>
     <jmh.version>1.17.4</jmh.version>
     <jmh.profilers.version>0.1.3</jmh.profilers.version>
     <nukleus.plugin.version>0.7.3</nukleus.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <jmh.profilers.version>0.1.3</jmh.profilers.version>
     <nukleus.plugin.version>0.7.3</nukleus.plugin.version>
     <nukleus.version>0.2</nukleus.version>
-    <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
+    <nukleus.http.spec.version>0.15</nukleus.http.spec.version>
     <reaktor.test.version>0.2</reaktor.test.version>
     <reaktor.version>0.1</reaktor.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,12 @@
     <checkstyle.suppressions.location>src/conf/checkstyle/suppressions.xml</checkstyle.suppressions.location>
 
     <junit.version>4.12</junit.version>
-    <k3po.version>develop-SNAPSHOT</k3po.version>
+    <k3po.version>3.0.0-alpha-63</k3po.version>
     <jmh.version>1.17.4</jmh.version>
     <jmh.profilers.version>0.1.3</jmh.profilers.version>
     <nukleus.plugin.version>0.7.3</nukleus.plugin.version>
     <nukleus.version>0.2</nukleus.version>
-    <nukleus.http.spec.version>0.14</nukleus.http.spec.version>
+    <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
     <reaktor.test.version>0.2</reaktor.test.version>
     <reaktor.version>0.1</reaktor.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/ServerConnectionState.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/ServerConnectionState.java
@@ -37,8 +37,9 @@ final class ServerConnectionState
     @Override
     public String toString()
     {
-        return String.format("[streamId=%016x, window=%d]",
-                getClass().getSimpleName(), streamId, window);
+        return String.format(
+                "[streamId=%016x, target=%s, window=%d, started=%b, pendingRequests=%d, endRequested=%b]",
+                getClass().getSimpleName(), streamId, target, window, started, pendingRequests, endRequested);
     }
 
     public void doEnd(Function<String, Target> supplyTarget)

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/Slab.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/Slab.java
@@ -95,6 +95,7 @@ public final class Slab
      */
     public MutableDirectBuffer buffer(int slot)
     {
+        assert slot >= 0 : "invalid slot: " + Integer.toString(slot);
         assert used.get(slot);
         final long slotAddressOffset = buffer.addressOffset() + (slot << bitsPerSlot);
         mutableFW.wrap(slotAddressOffset, slotCapacity);

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
@@ -266,8 +266,9 @@ public final class SourceInputStreamFactory
             // TODO: replace with connection pool (end)
 
             StringBuffer payloadText = new StringBuffer()
-                    .append("HTTP/1.1 ").append(Integer.toString(status)).append(" ").append(message).append("\r\n")
-                    .append("Connection: close\r\n\r\n");
+                    .append(String.format("HTTP/1.1 %d %s\r\n", status, message))
+                    .append("Connection: close\r\n")
+                    .append("\r\n");
 
             final DirectBuffer payload = new UnsafeBuffer(payloadText.toString().getBytes(StandardCharsets.UTF_8));
 
@@ -460,6 +461,7 @@ public final class SourceInputStreamFactory
                     // Incomplete request, not yet cached
                     slotIndex = slab.acquire(sourceId);
                 }
+
                 if (slotIndex == NO_SLOT)
                 {
                     // Out of slab memory

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
@@ -351,7 +351,9 @@ public final class SourceOutputStreamFactory
 
         private void doEnd()
         {
+            // TODO: Return target stream to connection pool or call doEnd on it to free resources
             target.removeThrottle(targetId);
+
             source.removeStream(sourceId);
             this.streamState = this::streamAfterEnd;
         }

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
@@ -243,12 +243,6 @@ public final class SourceOutputStreamFactory
 
                 correlateNew.accept(targetCorrelationId, correlation);
 
-                final Route route = optional.get();
-                target = route.target();
-                final long targetRef = route.targetRef();
-                target.doBegin(targetId, targetRef, targetCorrelationId);
-                target.setThrottle(targetId, this::handleThrottle);
-
                 String[] pseudoHeaders = new String[4];
 
                 StringBuilder headersChars = new StringBuilder();
@@ -309,7 +303,6 @@ public final class SourceOutputStreamFactory
                     {
                         // TODO: diagnostics (reset reason?)
                         source.doReset(sourceId);
-                        target.removeThrottle(targetId);
                         source.removeStream(sourceId);
                     }
                     else
@@ -320,6 +313,11 @@ public final class SourceOutputStreamFactory
                         slotOffset = 0;
                         this.streamState = this::streamBeforeHeadersWritten;
                         this.throttleState = this::throttleBeforeHeadersWritten;
+                        final Route route = optional.get();
+                        target = route.target();
+                        final long targetRef = route.targetRef();
+                        target.doBegin(targetId, targetRef, targetCorrelationId);
+                        target.setThrottle(targetId, this::handleThrottle);
                     }
                 }
             }

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceOutputStreamFactory.java
@@ -79,13 +79,13 @@ public final class SourceOutputStreamFactory
         Source source,
         LongFunction<List<Route>> supplyRoutes,
         LongSupplier supplyTargetId,
-        LongObjectBiConsumer<Correlation<?>> correlateNew2,
+        LongObjectBiConsumer<Correlation<?>> correlateNew,
         Slab slab)
     {
         this.source = source;
         this.supplyTargetId = supplyTargetId;
         this.supplyRoutes = supplyRoutes;
-        this.correlateNew = correlateNew2;
+        this.correlateNew = correlateNew;
         this.slab = slab;
     }
 

--- a/src/test/java/org/reaktivity/nukleus/http/internal/bench/HttpClientBM.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/bench/HttpClientBM.java
@@ -1,0 +1,361 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.http.internal.bench;
+
+import static java.lang.String.format;
+import static java.nio.ByteBuffer.allocateDirect;
+import static java.nio.file.FileVisitOption.FOLLOW_LINKS;
+import static java.util.Collections.emptyMap;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+import static org.agrona.IoUtil.ensureDirectoryExists;
+import static org.reaktivity.nukleus.Configuration.DIRECTORY_PROPERTY_NAME;
+import static org.reaktivity.nukleus.Configuration.STREAMS_BUFFER_CAPACITY_PROPERTY_NAME;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.Random;
+
+import org.agrona.LangUtil;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.AtomicBuffer;
+import org.agrona.concurrent.MessageHandler;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.concurrent.status.AtomicCounter;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Control;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+import org.reaktivity.nukleus.Configuration;
+import org.reaktivity.nukleus.http.internal.HttpController;
+import org.reaktivity.nukleus.http.internal.HttpStreams;
+import org.reaktivity.nukleus.http.internal.types.stream.BeginFW;
+import org.reaktivity.nukleus.http.internal.types.stream.DataFW;
+import org.reaktivity.nukleus.http.internal.types.stream.ResetFW;
+import org.reaktivity.nukleus.http.internal.types.stream.WindowFW;
+import org.reaktivity.reaktor.internal.Reaktor;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Fork(3)
+@Warmup(iterations = 1, time = 10, timeUnit = SECONDS)
+@Measurement(iterations = 3, time = 10, timeUnit = SECONDS)
+@OutputTimeUnit(SECONDS)
+public class HttpClientBM
+{
+    @State(Scope.Group)
+    public static class GroupState
+    {
+        private final Configuration configuration;
+        private final Reaktor reaktor;
+
+        private final BeginFW beginRO = new BeginFW();
+        private final DataFW dataRO = new DataFW();
+        private final WindowFW windowRO = new WindowFW();
+
+        private final BeginFW.Builder beginRW = new BeginFW.Builder();
+        private final DataFW.Builder dataRW = new DataFW.Builder();
+        private final WindowFW.Builder windowRW = new WindowFW.Builder();
+
+        private HttpStreams sourceOutputStreams;
+        private HttpStreams sourceOutputEstStreams;
+
+        private MutableDirectBuffer throttleBuffer;
+
+        private long sourceOutputRef;
+        private long streamsSourced;
+
+        private DataFW data;
+
+        private MessageHandler sourceInputEstHandler;
+        int availableSourceOutputWindow = 0;
+        final Random random = new Random();
+
+        {
+
+            final AtomicBuffer sourceOutputBeginBuffer = new UnsafeBuffer(new byte[256]);
+            beginRW.wrap(sourceOutputBeginBuffer, 0, sourceOutputBeginBuffer.capacity())
+            .streamId(streamsSourced++)
+            .referenceId(sourceOutputRef)
+            .correlationId(random.nextLong())
+            .extension(e -> e.reset()); // TODO: request headers
+
+            Properties properties = new Properties();
+            properties.setProperty(DIRECTORY_PROPERTY_NAME, "target/nukleus-benchmarks");
+            properties.setProperty(STREAMS_BUFFER_CAPACITY_PROPERTY_NAME, Long.toString(1024L * 1024L * 16L));
+
+            configuration = new Configuration(properties);
+            ensureDirectoryExists(configuration.directory().toFile(), configuration.directory().toString());
+
+            try
+            {
+                Files.walk(configuration.directory(), FOLLOW_LINKS)
+                     .map(Path::toFile)
+                     .forEach(File::delete);
+            }
+            catch (IOException ex)
+            {
+                LangUtil.rethrowUnchecked(ex);
+            }
+
+            reaktor = Reaktor.launch(configuration, n -> "http".equals(n), HttpController.class::isAssignableFrom);
+        }
+
+        @Setup(Level.Trial)
+        public void reinit() throws Exception
+        {
+            final HttpController controller = reaktor.controller(HttpController.class);
+
+            this.streamsSourced = 0;
+
+            final long targetRef = random.nextLong();
+
+            this.sourceOutputRef = controller.routeOutputNew("source", 0L, "target", targetRef, emptyMap()).get();
+
+            this.sourceOutputStreams = controller.streams("source");
+
+            this.sourceInputEstHandler = this::processBegin;
+
+            String payload = "Hello, world";
+            byte[] payloadBytes = payload.getBytes(StandardCharsets.UTF_8);
+
+            final AtomicBuffer sourceOutputDataBuffer = new UnsafeBuffer(new byte[256]);
+
+            this.data = dataRW.wrap(sourceOutputDataBuffer, 0, sourceOutputDataBuffer.capacity())
+                              .payload(p -> p.set(payloadBytes))
+                              .extension(e -> e.reset())
+                              .build();
+
+            String responsePayload =
+                    "POST / HTTP/1.1\r\n" +
+                    "Host: localhost:8080\r\n" +
+                    "Content-Length:12\r\n" +
+                    "\r\n" +
+                    "Hello, world";
+            byte[] responseBytes = responsePayload.getBytes(StandardCharsets.UTF_8);
+
+            this.throttleBuffer = new UnsafeBuffer(allocateDirect(SIZE_OF_LONG + SIZE_OF_INT));
+
+            boolean writeSucceeded = false;
+            for (int i=0; i < 100 && !writeSucceeded; i++)
+            {
+                Thread.sleep(100);
+                writeSucceeded = write();
+            }
+
+            if (writeSucceeded)
+            {
+                for (int i=0; i < 100 && sourceOutputEstStreams == null; i++)
+                {
+                    try
+                    {
+                        sourceOutputEstStreams = controller.streams("http", "source");
+                    }
+                    catch (IllegalStateException e)
+                    {
+                        Thread.sleep(100);
+                    }
+                }
+                int result = read();
+                if (result <= 0)
+                {
+                    throw new RuntimeException("reinit: read() failed");
+                }
+            }
+            else
+            {
+                throw new RuntimeException("reinit: write() failed");
+            }
+
+        }
+
+        @TearDown(Level.Trial)
+        public void reset() throws Exception
+        {
+            HttpController controller = reaktor.controller(HttpController.class);
+
+            controller.unrouteInputNew("source", sourceOutputRef, "http", 0L, null).get();
+
+            this.sourceOutputStreams.close();
+            this.sourceOutputStreams = null;
+
+            this.sourceOutputEstStreams.close();
+            this.sourceOutputEstStreams = null;
+        }
+
+        private int read()
+        {
+            return sourceOutputEstStreams.readStreams(this::handleSourceOutputEst);
+        }
+
+        private boolean write()
+        {
+            beginRW.streamId(streamsSourced++);
+            BeginFW begin = beginRW.build();
+            this.sourceOutputStreams.writeStreams(begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof());
+            sourceOutputStreams.readThrottle(this::sourceInputThrottle);
+            boolean result = false;
+            while (!result)
+            {
+                result = availableSourceOutputWindow >= data.length();
+                if (result)
+                {
+                    result = sourceOutputStreams.writeStreams(data.typeId(), data.buffer(), 0, data.limit());
+                    if (result)
+                    {
+                        availableSourceOutputWindow -= data.length();
+                    }
+                    else
+                    {
+                        System.out.println(format("write failed, availableSourceInputWindow = %d", availableSourceOutputWindow));
+                        break;
+                    }
+                }
+            }
+            return result;
+        }
+
+        private void sourceInputThrottle(
+            int msgTypeId,
+            MutableDirectBuffer buffer,
+            int index,
+            int length)
+        {
+            switch (msgTypeId)
+            {
+            case WindowFW.TYPE_ID:
+                windowRO.wrap(buffer, index, index + length);
+                availableSourceOutputWindow += windowRO.update();
+//                System.out.println(format("sourceInputThrottle: received window update %d, availableSourceInputWindow=%d",
+//                        windowRO.update(), availableSourceInputWindow));
+                break;
+            case ResetFW.TYPE_ID:
+                System.out.println("ERROR: reset detected in sourceInputThrottle");
+                break;
+            default:
+                System.out.println(format("ERROR: unexpected msgTypeId %d detected in sourceInputThrottle",
+                        msgTypeId));
+                break;
+            }
+        }
+
+        private void handleSourceOutputEst(
+            int msgTypeId,
+            MutableDirectBuffer buffer,
+            int index,
+            int length)
+        {
+            sourceInputEstHandler.onMessage(msgTypeId, buffer, index, length);
+        }
+
+        private void processBegin(
+            int msgTypeId,
+            MutableDirectBuffer buffer,
+            int index,
+            int length)
+        {
+            beginRO.wrap(buffer, index, index + length);
+            final long streamId = beginRO.streamId();
+            doWindow(streamId, 8192);
+
+            this.sourceInputEstHandler = this::processData;
+        }
+
+        private void processData(
+            int msgTypeId,
+            MutableDirectBuffer buffer,
+            int index,
+            int length)
+        {
+            dataRO.wrap(buffer, index, index + length);
+            final long streamId = dataRO.streamId();
+            final int update = dataRO.length();
+            doWindow(streamId, update);
+        }
+
+        private void doWindow(
+            final long streamId,
+            final int update)
+        {
+            final WindowFW window = windowRW.wrap(throttleBuffer, 0, throttleBuffer.capacity())
+                    .streamId(streamId)
+                    .update(update)
+                    .build();
+            sourceOutputEstStreams.writeThrottle(window.typeId(), window.buffer(), window.offset(), window.sizeof());
+        }
+    }
+
+    @Benchmark
+    @Group("throughput")
+    @GroupThreads(1)
+    public int writer(final GroupState state, final Control control) throws Exception
+    {
+        boolean result;
+        while (!(result = state.write()) && !control.stopMeasurement)
+        {
+            Thread.yield();
+        }
+        return result ? 1 : 0;
+    }
+
+    @Benchmark
+    @Group("throughput")
+    @GroupThreads(1)
+    public int reader(final GroupState state, final Control control) throws Exception
+    {
+        int result;
+        while ((result = state.read()) == 0 && !control.stopMeasurement)
+        {
+            Thread.yield();
+        }
+        return result;
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+                .include(HttpClientBM.class.getSimpleName())
+                .forks(0)
+                .threads(1)
+                .warmupIterations(0)
+                .measurementIterations(1)
+                .measurementTime(new TimeValue(10, SECONDS))
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/org/reaktivity/nukleus/http/internal/bench/HttpClientBM.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/bench/HttpClientBM.java
@@ -374,7 +374,7 @@ public class HttpClientBM
                 }
                 break;
             case ResetFW.TYPE_ID:
-                System.out.println("ERROR: reset detected in client accept throttle");
+                System.out.println("WARNING: reset detected in client accept throttle");
                 break;
             default:
                 System.out.println(format("ERROR: unexpected msgTypeId %d detected in client accept throttle",
@@ -633,7 +633,7 @@ public class HttpClientBM
                 }
                 break;
             case ResetFW.TYPE_ID:
-                System.out.println("ERROR: reset detected in remote writer throttle");
+                System.out.println("WARNING: reset detected in remote writer throttle");
                 break;
             default:
                 System.out.println(format("ERROR: unexpected msgTypeId %d detected in remote writer throttle",

--- a/src/test/java/org/reaktivity/nukleus/http/internal/routable/stream/SlabTest.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/routable/stream/SlabTest.java
@@ -103,6 +103,20 @@ public class SlabTest
         assertEquals(16, buffer.capacity());
     }
 
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void bufferShouldBoundsCheckByDefault() throws Exception
+    {
+        Slab slab = new Slab(256, 16);
+        slab.buffer(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void bufferShouldCheckSlotAcquiredByDefault() throws Exception
+    {
+        Slab slab = new Slab(256, 16);
+        slab.buffer(11);
+    }
+
     @Test
     public void freeShouldMakeSlotAvailableForReuse() throws Exception
     {

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/ConnectionManagementIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/ConnectionManagementIT.java
@@ -18,6 +18,7 @@ package org.reaktivity.nukleus.http.internal.streams.rfc7230;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -77,6 +78,19 @@ public class ConnectionManagementIT
 
     @Test
     @Specification({
+        "${route}/input/new/controller",
+        "${streams}/multiple.requests.same.connection/server/source",
+        "${streams}/multiple.requests.same.connection/server/target" })
+    public void shouldAcceptMultipleRequestsOnSameConnection() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_INPUT");
+        k3po.notifyBarrier("ROUTED_OUTPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${route}/output/new/controller",
         "${streams}/response.status.101.with.upgrade/client/source",
         "${streams}/response.status.101.with.upgrade/client/target" })
@@ -93,7 +107,21 @@ public class ConnectionManagementIT
         "${route}/output/new/controller",
         "${streams}/multiple.requests/client/source",
         "${streams}/multiple.requests/client/target" })
-    public void shouldAcceptMultipleRequestsClient() throws Exception
+    public void shouldIssueMultipleRequests() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.notifyBarrier("ROUTED_INPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/output/new/controller",
+        "${streams}/multiple.requests.same.connection/client/source",
+        "${streams}/multiple.requests.same.connection/client/target" })
+    @Ignore("Not yet supported")
+    public void shouldIssueMultipleRequestsUsingConnectionPool() throws Exception
     {
         k3po.start();
         k3po.awaitBarrier("ROUTED_OUTPUT");


### PR DESCRIPTION
- Add HttpClientBM: benchmark for client. This works as follows:
  - requestWriter thread: writes requests to source output (begin data end)
  - remoteEcho thread: reads encoded requests from target output and writes (raw) responses to target input established
  - responseReader thread: reads decoded  responses from source input established
- Add bounds check on Slab
- Handle all cases where a slab cannot be acquired because all available slots are in use
- Add tests for multiple requests
- Make sure we always reset the source stream for all cases of invalid request or unable to process request due to lack of slab memory, and that we also set header connection: close for cases where we write an http response
