### PR TITLE
Add support for chunked transfer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <jmh.profilers.version>0.1.3</jmh.profilers.version>
     <nukleus.plugin.version>0.7.3</nukleus.plugin.version>
     <nukleus.version>0.2</nukleus.version>
-    <nukleus.http.spec.version>0.20</nukleus.http.spec.version>
+    <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
     <reaktor.test.version>0.4</reaktor.test.version>
     <reaktor.version>0.1</reaktor.version>
     <k3po.nukleus.ext.version>0.4.2</k3po.nukleus.ext.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <nukleus.version>0.2</nukleus.version>
     <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
     <reaktor.test.version>0.4</reaktor.test.version>
-    <reaktor.version>0.1</reaktor.version>
+    <reaktor.version>0.2.2</reaktor.version>
     <k3po.nukleus.ext.version>0.4.2</k3po.nukleus.ext.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <jmh.profilers.version>0.1.3</jmh.profilers.version>
     <nukleus.plugin.version>0.7.8</nukleus.plugin.version>
     <nukleus.version>0.2</nukleus.version>
-    <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
+    <nukleus.http.spec.version>0.22</nukleus.http.spec.version>
     <reaktor.test.version>0.4</reaktor.test.version>
     <reaktor.version>0.2.2</reaktor.version>
     <k3po.nukleus.ext.version>0.5</k3po.nukleus.ext.version>

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/ServerAcceptState.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/ServerAcceptState.java
@@ -32,6 +32,7 @@ final class ServerAcceptState
     int window;
     int pendingRequests;
     boolean endRequested;
+    boolean persistent = true;
 
     ServerAcceptState(long streamId, Target replyTarget, MessageHandler initialThrottle)
     {

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
@@ -790,6 +790,7 @@ public final class SourceInputStreamFactory
                     else
                     {
                         isChunkedTransfer = true;
+                        headers.put(name, value);
                     }
 
                 }

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/SourceInputStreamFactory.java
@@ -122,8 +122,8 @@ public final class SourceInputStreamFactory
         private long sourceRef;
         private int window;
         private int contentRemaining;
-        boolean isChunkedTransfer;
-        int chunkSizeRemaining;
+        private boolean isChunkedTransfer;
+        private int chunkSizeRemaining;
         private int availableTargetWindow;
         private boolean hasUpgrade;
         private Correlation<ServerAcceptState> correlation;

--- a/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetInputEstablishedStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/routable/stream/TargetInputEstablishedStreamFactory.java
@@ -810,6 +810,6 @@ public final class TargetInputEstablishedStreamFactory
     @FunctionalInterface
     private interface DecoderState
     {
-        int decode(DirectBuffer buffer, int offset, int length);
+        int decode(DirectBuffer buffer, int offset, int limit);
     }
 }

--- a/src/test/java/org/reaktivity/nukleus/http/internal/bench/HttpClientBM.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/bench/HttpClientBM.java
@@ -74,7 +74,7 @@ import org.reaktivity.nukleus.http.internal.types.stream.EndFW;
 import org.reaktivity.nukleus.http.internal.types.stream.HttpBeginExFW;
 import org.reaktivity.nukleus.http.internal.types.stream.ResetFW;
 import org.reaktivity.nukleus.http.internal.types.stream.WindowFW;
-import org.reaktivity.reaktor.internal.Reaktor;
+import org.reaktivity.reaktor.Reaktor;
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
@@ -116,7 +116,11 @@ public class HttpClientBM
             configuration = new Configuration(properties);
             ensureDirectoryExists(configuration.directory().toFile(), configuration.directory().toString());
 
-            reaktor = Reaktor.init(configuration, n -> "http".equals(n), HttpController.class::isAssignableFrom);
+            reaktor = Reaktor.builder()
+                         .config(configuration)
+                         .discover((String t) -> "http".equals(t))
+                         .discover(HttpController.class::isAssignableFrom)
+                         .build();
         }
 
         @Setup(Level.Iteration)
@@ -133,7 +137,11 @@ public class HttpClientBM
             {
                 LangUtil.rethrowUnchecked(ex);
             }
-            reaktor = Reaktor.init(configuration, n -> "http".equals(n), HttpController.class::isAssignableFrom);
+            reaktor = Reaktor.builder()
+                    .config(configuration)
+                    .discover((String t) -> "http".equals(t))
+                    .discover(HttpController.class::isAssignableFrom)
+                    .build();
             reaktor.start();
             System.out.println("Reaktor started");
 

--- a/src/test/java/org/reaktivity/nukleus/http/internal/bench/HttpServerBM.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/bench/HttpServerBM.java
@@ -66,7 +66,7 @@ import org.reaktivity.nukleus.http.internal.types.stream.BeginFW;
 import org.reaktivity.nukleus.http.internal.types.stream.DataFW;
 import org.reaktivity.nukleus.http.internal.types.stream.ResetFW;
 import org.reaktivity.nukleus.http.internal.types.stream.WindowFW;
-import org.reaktivity.reaktor.internal.Reaktor;
+import org.reaktivity.reaktor.Reaktor;
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
@@ -101,8 +101,11 @@ public class HttpServerBM
                 LangUtil.rethrowUnchecked(ex);
             }
 
-            reaktor = Reaktor.launch(configuration, n -> "http".equals(n), HttpController.class::isAssignableFrom);
-        }
+            reaktor = Reaktor.builder()
+                    .config(configuration)
+                    .discover((String t) -> "http".equals(t))
+                    .discover(HttpController.class::isAssignableFrom)
+                    .build();        }
 
         private final BeginFW beginRO = new BeginFW();
         private final DataFW dataRO = new DataFW();

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/agrona/FlowControlLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/agrona/FlowControlLimitsIT.java
@@ -60,18 +60,6 @@ public class FlowControlLimitsIT
     @Test
     @Specification({
         "${route}/input/new/controller",
-        "${streams}/request.headers.too.long/server/source" })
-    public void shouldRejectRequestExceedingMaximumHeadersSize() throws Exception
-    {
-        k3po.start();
-        k3po.awaitBarrier("ROUTED_INPUT");
-        k3po.notifyBarrier("ROUTED_OUTPUT");
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
-        "${route}/input/new/controller",
         "${streams}/response.headers.too.long/server/source",
         "${streams}/response.headers.too.long/server/target" })
     public void shouldNotWriteResponseExceedingMaximumHeadersSize() throws Exception

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/TransferCodingsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/TransferCodingsIT.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.http.internal.streams.rfc7230.client;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.reaktivity.reaktor.test.NukleusRule;
+
+@Ignore // TODO: implement chunked transfer
+public class TransferCodingsIT
+{
+    private final K3poRule k3po = new K3poRule()
+            .addScriptRoot("route", "org/reaktivity/specification/nukleus/http/control/route")
+            .addScriptRoot("server", "org/reaktivity/specification/http/rfc7230/transfer.codings")
+            .addScriptRoot("client", "org/reaktivity/specification/nukleus/http/streams/rfc7230/transfer.codings");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
+
+    private final NukleusRule nukleus = new NukleusRule("http")
+        .directory("target/nukleus-itests")
+        .commandBufferCapacity(1024)
+        .responseBufferCapacity(1024)
+        .counterValuesBufferCapacity(1024);
+
+    @Rule
+    public final TestRule chain = outerRule(nukleus).around(k3po).around(timeout);
+
+    @Test
+    @Specification({
+        "${route}/output/new/controller",
+        "${client}/request.transfer.encoding.chunked/client",
+        "${server}/request.transfer.encoding.chunked/server" })
+    public void requestTransferEncodingChunked() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/output/new/controller",
+        "${client}/response.transfer.encoding.chunked/client",
+        "${server}/response.transfer.encoding.chunked/server" })
+    public void responseTransferEncodingChunked() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Ignore("${scripts}/requires enhancement https://github.com/k3po/k3po/issues/313")
+    public void requestTransferEncodingChunkedExtension() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Ignore("${scripts}/requires enhancement https://github.com/k3po/k3po/issues/313")
+    public void responseTransferEncodingChunkedExtension() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/output/new/controller",
+        "${client}/request.transfer.encoding.chunked.with.trailer/client",
+        "${server}/request.transfer.encoding.chunked.with.trailer/server" })
+    public void requestTransferEncodingChunkedWithTrailer() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/output/new/controller",
+        "${client}/response.transfer.encoding.chunked.with.trailer/client",
+        "${server}/response.transfer.encoding.chunked.with.trailer/server" })
+    public void responseTransferEncodingChunkedWithTrailer() throws Exception
+    {
+        k3po.finish();
+    }
+
+}

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/TransferCodingsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/TransferCodingsIT.java
@@ -28,7 +28,6 @@ import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 import org.reaktivity.reaktor.test.NukleusRule;
 
-@Ignore // TODO: implement chunked transfer
 public class TransferCodingsIT
 {
     private final K3poRule k3po = new K3poRule()
@@ -36,7 +35,7 @@ public class TransferCodingsIT
             .addScriptRoot("server", "org/reaktivity/specification/http/rfc7230/transfer.codings")
             .addScriptRoot("client", "org/reaktivity/specification/nukleus/http/streams/rfc7230/transfer.codings");
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
+    private final TestRule timeout = new DisableOnDebug(new Timeout(6, SECONDS));
 
     private final NukleusRule nukleus = new NukleusRule("http")
         .directory("target/nukleus-itests")
@@ -52,6 +51,7 @@ public class TransferCodingsIT
         "${route}/output/new/controller",
         "${client}/request.transfer.encoding.chunked/client",
         "${server}/request.transfer.encoding.chunked/server" })
+    @Ignore // TODO: implement chunked request encoding
     public void requestTransferEncodingChunked() throws Exception
     {
         k3po.finish();
@@ -86,6 +86,7 @@ public class TransferCodingsIT
         "${route}/output/new/controller",
         "${client}/request.transfer.encoding.chunked.with.trailer/client",
         "${server}/request.transfer.encoding.chunked.with.trailer/server" })
+    @Ignore // TODO: implement chunked request encoding
     public void requestTransferEncodingChunkedWithTrailer() throws Exception
     {
         k3po.finish();

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/server/MessageFormatIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/server/MessageFormatIT.java
@@ -119,6 +119,15 @@ public class MessageFormatIT
     @Test
     @Specification({
         "${route}/input/new/controller",
+        "${client}/incomplete.request.with.unimplemented.method/client"})
+    public void incompleteRequestWithUnimplementedMethod() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
         "${client}/request.with.unimplemented.method/client"})
     public void requestWithUnimplementedMethod() throws Exception
     {

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/server/TransferCodingsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/server/TransferCodingsIT.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.http.internal.streams.rfc7230.server;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.reaktivity.reaktor.test.NukleusRule;
+
+@Ignore // TODO: implement chunked transfer
+public class TransferCodingsIT
+{
+    private final K3poRule k3po = new K3poRule()
+            .addScriptRoot("route", "org/reaktivity/specification/nukleus/http/control/route")
+            .addScriptRoot("client", "org/reaktivity/specification/http/rfc7230/transfer.codings")
+            .addScriptRoot("server", "org/reaktivity/specification/nukleus/http/streams/rfc7230/transfer.codings");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
+
+    private final NukleusRule nukleus = new NukleusRule("http")
+        .directory("target/nukleus-itests")
+        .commandBufferCapacity(1024)
+        .responseBufferCapacity(1024)
+        .counterValuesBufferCapacity(1024);
+
+    @Rule
+    public final TestRule chain = outerRule(nukleus).around(k3po).around(timeout);
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
+        "${client}/request.transfer.encoding.chunked/client",
+        "${server}/request.transfer.encoding.chunked/server" })
+    public void requestTransferEncodingChunked() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
+        "${client}/response.transfer.encoding.chunked/client",
+        "${server}/response.transfer.encoding.chunked/server" })
+    public void responseTransferEncodingChunked() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Ignore("${scripts}/requires enhancement https://github.com/k3po/k3po/issues/313")
+    public void requestTransferEncodingChunkedExtension() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Ignore("${scripts}/requires enhancement https://github.com/k3po/k3po/issues/313")
+    public void responseTransferEncodingChunkedExtension() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
+        "${client}/request.transfer.encoding.chunked.with.trailer/client",
+        "${server}/request.transfer.encoding.chunked.with.trailer/server" })
+    public void requestTransferEncodingChunkedWithTrailer() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
+        "${client}/response.transfer.encoding.chunked.with.trailer/client",
+        "${server}/response.transfer.encoding.chunked.with.trailer/server" })
+    public void responseTransferEncodingChunkedWithTrailer() throws Exception
+    {
+        k3po.finish();
+    }
+
+}

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/server/TransferCodingsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/server/TransferCodingsIT.java
@@ -28,7 +28,6 @@ import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 import org.reaktivity.reaktor.test.NukleusRule;
 
-@Ignore // TODO: implement chunked transfer
 public class TransferCodingsIT
 {
     private final K3poRule k3po = new K3poRule()
@@ -53,6 +52,16 @@ public class TransferCodingsIT
         "${client}/request.transfer.encoding.chunked/client",
         "${server}/request.transfer.encoding.chunked/server" })
     public void requestTransferEncodingChunked() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
+        "${client}/invalid.chunked.request.no.crlf.at.end.of.chunk/client",
+        "${server}/invalid.chunked.request.no.crlf.at.end.of.chunk/server" })
+    public void invalidRequestTransferEncodingChunked() throws Exception
     {
         k3po.finish();
     }

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/server/TransferCodingsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/server/TransferCodingsIT.java
@@ -71,6 +71,7 @@ public class TransferCodingsIT
         "${route}/input/new/controller",
         "${client}/response.transfer.encoding.chunked/client",
         "${server}/response.transfer.encoding.chunked/server" })
+    @Ignore // TODO: implement encoding chunked responses
     public void responseTransferEncodingChunked() throws Exception
     {
         k3po.finish();
@@ -105,6 +106,7 @@ public class TransferCodingsIT
         "${route}/input/new/controller",
         "${client}/response.transfer.encoding.chunked.with.trailer/client",
         "${server}/response.transfer.encoding.chunked.with.trailer/server" })
+    @Ignore // TODO: implement encoding chunked responses
     public void responseTransferEncodingChunkedWithTrailer() throws Exception
     {
         k3po.finish();

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/server/TransferCodingsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/server/TransferCodingsIT.java
@@ -35,7 +35,7 @@ public class TransferCodingsIT
             .addScriptRoot("client", "org/reaktivity/specification/http/rfc7230/transfer.codings")
             .addScriptRoot("server", "org/reaktivity/specification/nukleus/http/streams/rfc7230/transfer.codings");
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
+    private final TestRule timeout = new DisableOnDebug(new Timeout(6, SECONDS));
 
     private final NukleusRule nukleus = new NukleusRule("http")
         .directory("target/nukleus-itests")


### PR DESCRIPTION
For now only decoding of chunked requests and responses is implemented.

This PR also includes changes to align the code in TargetInputEstablishedStreamFactory with SourceInputStreamFactory so in both cases the slab management is kept in one place instead of being spread throughout the decoding states.