### PR TITLE
connectReply and acceptReply aligned optimization

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientConnectReplyStream.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientConnectReplyStream.java
@@ -953,6 +953,10 @@ final class ClientConnectReplyStream implements MessageConsumer
             decodeBufferedData();
         }
 
+        if (connectReplyWindowPadding >= acceptReplyWindowPadding)
+        {
+            connectReplyWindowAligned = true;
+        }
         doSendWindowIfAligned();
     }
 


### PR DESCRIPTION
If WINDOW frame is received and connectReplyWindowPadding is already more than
the acceptReplyWindowPadding, then no need to defer the WINDOW. One can send the WINDOW immediately.