### PR TITLE
Fix for issue 59

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,10 +54,10 @@
     <k3po.nukleus.ext.version>0.16</k3po.nukleus.ext.version>
 
     <nukleus.plugin.version>0.19</nukleus.plugin.version>
-    <nukleus.version>0.13</nukleus.version>
+    <nukleus.version>0.14</nukleus.version>
 
-    <nukleus.http.spec.version>0.43</nukleus.http.spec.version>
-    <reaktor.version>0.33</reaktor.version>
+    <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
+    <reaktor.version>0.34</reaktor.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <checkstyle.config.location>src/conf/checkstyle/configuration.xml</checkstyle.config.location>
     <checkstyle.suppressions.location>src/conf/checkstyle/suppressions.xml</checkstyle.suppressions.location>
-    <jacoco.coverage.ratio>0.63</jacoco.coverage.ratio>
+    <jacoco.coverage.ratio>0.64</jacoco.coverage.ratio>
     <jacoco.missed.count>42</jacoco.missed.count>
 
     <junit.version>4.12</junit.version>

--- a/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientConnectReplyStream.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientConnectReplyStream.java
@@ -457,8 +457,7 @@ final class ClientConnectReplyStream implements MessageConsumer
         slotOffset = offset;
         if (slotOffset == slotPosition)
         {
-            factory.bufferPool.release(slotIndex);
-            slotIndex = NO_SLOT;
+            releaseSlotIfNecessary();
             streamState = this::handleStreamWhenNotBuffering;
             if (endDeferred)
             {

--- a/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientStreamFactory.java
@@ -201,6 +201,7 @@ public final class ClientStreamFactory implements StreamFactory
             if (extension.sizeof() > 0)
             {
                 final HttpRouteExFW routeEx = extension.get(routeExRO::wrap);
+                // TODO: the following test always returns true, and looks incorrect.
                 headersMatch = routeEx.headers().anyMatch(
                         h -> !Objects.equals(h.value(), headers.get(h.name())));
             }

--- a/src/main/java/org/reaktivity/nukleus/http/internal/stream/ServerStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/stream/ServerStreamFactory.java
@@ -16,6 +16,7 @@
 package org.reaktivity.nukleus.http.internal.stream;
 
 import static java.util.Objects.requireNonNull;
+import static org.reaktivity.nukleus.http.internal.util.HttpUtil.HTTP_STATUS_OK;
 
 import java.nio.charset.StandardCharsets;
 import java.util.function.LongSupplier;
@@ -165,7 +166,7 @@ public final class ServerStreamFactory implements StreamFactory
 
         void reset()
         {
-            status = 200;
+            status = HTTP_STATUS_OK;
             message = "OK";
         }
     }

--- a/src/main/java/org/reaktivity/nukleus/http/internal/util/HttpUtil.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/util/HttpUtil.java
@@ -20,6 +20,14 @@ import static java.lang.Character.toUpperCase;
 public final class HttpUtil
 {
 
+    public static final int HTTP_STATUS_OK = 200;
+    public static final int HTTP_STATUS_BAD_REQUEST = 400;
+    public static final int HTTP_STATUS_NOT_FOUND = 404;
+    public static final int HTTP_STATUS_NOT_IMPLEMENTED = 501;
+    public static final int HTTP_STATUS_BAD_GATEWAY = 502;
+    public static final int HTTP_STATUS_SERVICE_UNAVAILABLE = 503;
+    public static final int HTTP_STATUS_VERSION_NOT_SUPPORTED = 505;
+
     public static void appendHeader(StringBuilder payload, String name, String value)
     {
         int pos = name.indexOf('-');

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
@@ -90,9 +90,9 @@ public class ConnectionManagementPoolSize1IT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/request.and.503.response/client",
+        "${client}/request.and.502.response/client",
         "${server}/request.incomplete.response.headers.and.abort/server" })
-    public void shouldGive503ResponseAndFreeConnectionWhenConnectReplyStreamIsAbortedBeforeResponseHeadersComplete()
+    public void shouldGive502ResponseAndFreeConnectionWhenConnectReplyStreamIsAbortedBeforeResponseHeadersComplete()
             throws Exception
     {
         k3po.finish();
@@ -101,9 +101,9 @@ public class ConnectionManagementPoolSize1IT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/request.and.503.response/client",
+        "${client}/request.and.502.response/client",
         "${server}/request.incomplete.response.headers.and.end/server" })
-    public void shouldGive503ResponseAndFreeConnectionWhenConnectReplyStreamEndsBeforeResponseHeadersComplete() throws Exception
+    public void shouldGive502ResponseAndFreeConnectionWhenConnectReplyStreamEndsBeforeResponseHeadersComplete() throws Exception
     {
         k3po.finish();
     }
@@ -112,9 +112,9 @@ public class ConnectionManagementPoolSize1IT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/request.and.503.response/client",
+        "${client}/request.and.502.response/client",
         "${server}/request.incomplete.response.headers.and.reset/server" })
-    public void shouldGive503ResponseAndFreeConnectionWhenConnectStreamIsResetBeforeResponseHeadersComplete() throws Exception
+    public void shouldGive502ResponseAndFreeConnectionWhenConnectStreamIsResetBeforeResponseHeadersComplete() throws Exception
     {
         k3po.finish();
     }
@@ -122,9 +122,9 @@ public class ConnectionManagementPoolSize1IT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/request.and.503.response/client",
+        "${client}/request.and.502.response/client",
         "${server}/request.no.response.and.end/server" })
-    public void shouldGive503ResponseAndFreeConnectionWhenConnectReplyStreamEndsBeforeResponseReceived() throws Exception
+    public void shouldGive502ResponseAndFreeConnectionWhenConnectReplyStreamEndsBeforeResponseReceived() throws Exception
     {
         k3po.finish();
     }
@@ -133,9 +133,9 @@ public class ConnectionManagementPoolSize1IT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/request.and.503.response/client",
+        "${client}/request.and.502.response/client",
         "${server}/request.no.response.and.reset/server" })
-    public void shouldGive503ResponseAndFreeConnectionWhenConnectStreamIsResetBeforeResponseReceived() throws Exception
+    public void shouldGive502ResponseAndFreeConnectionWhenConnectStreamIsResetBeforeResponseReceived() throws Exception
     {
         k3po.finish();
     }

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/FlowControlLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/FlowControlLimitsIT.java
@@ -123,4 +123,14 @@ public class FlowControlLimitsIT
         k3po.finish();
     }
 
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/flow.control/response.with.unknown.transfer.encoding/client",
+        "${server}/flow.control/response.with.unknown.transfer.encoding/server"})
+    public void shouldAbortClientAcceptReplyWhenResponseUnknownTransferEncoding() throws Exception
+    {
+        k3po.finish();
+    }
+
 }

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/FlowControlLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/FlowControlLimitsIT.java
@@ -106,7 +106,7 @@ public class FlowControlLimitsIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/flow.control/response.headers.too.long/client.no.response",
+        "${client}/flow.control/response.headers.too.long/client.502.response",
         "${server}/flow.control/response.headers.too.long/server.response.reset"})
     public void shouldRejectResponseWithHeadersTooLong() throws Exception
     {


### PR DESCRIPTION
Fix for #59. Also generally improves how we handle invalid responses when running as an HTTP client by (a) avoiding an NPE that happened in some cases and (b) reporting response status 502  instead of 503 to better conform to [RFC 7231](https://tools.ietf.org/html/rfc7231#section-6.6.3).

Requires https://github.com/reaktivity/nukleus-http.spec/pull/44