### PR TITLE
503 with Retry-After

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/jitsni/nukleus-http.spec
+  - cd nukleus-http.spec
+  - git checkout 503.retry.after
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk9
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/jitsni/nukleus-http.spec
-  - cd nukleus-http.spec
-  - git checkout 503.retry.after
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk9
 install: mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.http.spec.version>0.54</nukleus.http.spec.version>
+    <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
     <reaktor.version>0.56</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
+    <nukleus.http.spec.version>0.55</nukleus.http.spec.version>
     <reaktor.version>0.56</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientAcceptStream.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientAcceptStream.java
@@ -219,9 +219,9 @@ final class ClientAcceptStream implements ConnectionRequest, Consumer<Connection
                 this.throttleState = this::throttleBeforeHeadersWritten;
                 target = factory.router.supplyTarget(connectName);
                 connectionPool = getConnectionPool(connectName, connectRef);
-                boolean acquired = connectionPool.acquire(this);
+                Connection connection = connectionPool.acquire(this);
                 // No backend connection, send 503 with Retry-After
-                if (!acquired)
+                if (connection == null)
                 {
                     MessageConsumer acceptReply = factory.router.supplyTarget(acceptName);
                     long targetId = factory.supplyStreamId.getAsLong();

--- a/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientAcceptStream.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientAcceptStream.java
@@ -207,7 +207,7 @@ final class ClientAcceptStream implements ConnectionRequest, Consumer<Connection
             {
                 // TODO: diagnostics (reset reason?)
                 factory.writer.doReset(acceptThrottle, acceptId, 0L);
-                factory.bufferPool.release(slotIndex);
+                releaseSlotIfNecessary();
             }
             else
             {
@@ -219,7 +219,18 @@ final class ClientAcceptStream implements ConnectionRequest, Consumer<Connection
                 this.throttleState = this::throttleBeforeHeadersWritten;
                 target = factory.router.supplyTarget(connectName);
                 connectionPool = getConnectionPool(connectName, connectRef);
-                connectionPool.acquire(this);
+                boolean acquired = connectionPool.acquire(this);
+                // No backend connection, send 503 with Retry-After
+                if (!acquired)
+                {
+                    MessageConsumer acceptReply = factory.router.supplyTarget(acceptName);
+                    long targetId = factory.supplyStreamId.getAsLong();
+                    factory.writer.doHttpBegin(acceptReply, targetId, 0L, 0L, acceptCorrelationId,
+                            hs -> hs.item(h -> h.name(":status").value("503"))
+                                    .item(h -> h.name("retry-after").value("0")));
+                    factory.writer.doHttpEnd(acceptReply, targetId, 0L);
+                    releaseSlotIfNecessary();
+                }
             }
         }
     }
@@ -481,12 +492,7 @@ final class ClientAcceptStream implements ConnectionRequest, Consumer<Connection
         factory.abortRO.wrap(buffer, index, index + length);
         releaseSlotIfNecessary();
 
-        if (connection == null)
-        {
-            // request still enqueued, remove it from the queue
-            connectionPool.cancel(this);
-        }
-        else
+        if (connection != null)
         {
             factory.correlations.remove(connection.correlationId);
             connection.persistent = false;
@@ -519,18 +525,6 @@ final class ClientAcceptStream implements ConnectionRequest, Consumer<Connection
     public Consumer<Connection> getConsumer()
     {
         return this;
-    }
-
-    @Override
-    public void next(ConnectionRequest request)
-    {
-        nextConnectionRequest = request;
-    }
-
-    @Override
-    public ConnectionRequest next()
-    {
-        return nextConnectionRequest;
     }
 
     @Override

--- a/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientConnectReplyStream.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientConnectReplyStream.java
@@ -456,11 +456,10 @@ final class ClientConnectReplyStream implements MessageConsumer
     private void decodeBufferedData()
     {
         MutableDirectBuffer slot = factory.bufferPool.buffer(slotIndex);
-        int offset = decode(slot, slotOffset, slotPosition);
-        slotOffset = offset;
+        slotOffset = decode(slot, slotOffset, slotPosition);
         if (slotOffset == slotPosition)
         {
-            factory.bufferPool.release(slotIndex);
+            releaseSlotIfNecessary();
             slotIndex = NO_SLOT;
             streamState = this::handleStreamWhenNotBuffering;
             if (endDeferred)
@@ -574,7 +573,7 @@ final class ClientConnectReplyStream implements MessageConsumer
             String connectionOptions = headers.get("connection");
             if (connectionOptions != null)
             {
-                Arrays.asList(connectionOptions.toLowerCase().split(",")).stream().forEach((element) ->
+                Arrays.stream(connectionOptions.toLowerCase().split(",")).forEach((element) ->
                 {
                     if (element.equals("close"))
                     {

--- a/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientStreamFactory.java
@@ -78,8 +78,6 @@ public final class ClientStreamFactory implements StreamFactory
     final RouteManager router;
     final LongSupplier supplyStreamId;
     final LongSupplier supplyCorrelationId;
-    final LongSupplier incrementEnqueues;
-    final LongSupplier incrementDequeues;
     final BufferPool bufferPool;
     final MessageWriter writer;
     long supplyTraceId;
@@ -100,8 +98,6 @@ public final class ClientStreamFactory implements StreamFactory
         BufferPool bufferPool,
         LongSupplier supplyStreamId,
         LongSupplier supplyCorrelationId,
-        LongSupplier incrementEnqueues,
-        LongSupplier incrementDequeues,
         Long2ObjectHashMap<Correlation<?>> correlations)
     {
         this.router = requireNonNull(router);
@@ -109,8 +105,6 @@ public final class ClientStreamFactory implements StreamFactory
         this.bufferPool = requireNonNull(bufferPool);
         this.supplyStreamId = requireNonNull(supplyStreamId);
         this.supplyCorrelationId = supplyCorrelationId;
-        this.incrementEnqueues = incrementEnqueues;
-        this.incrementDequeues = incrementDequeues;
         this.correlations = requireNonNull(correlations);
         this.connectionPools = new HashMap<>();
         this.maximumConnectionsPerRoute = configuration.maximumConnectionsPerRoute();

--- a/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientStreamFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientStreamFactoryBuilder.java
@@ -15,7 +15,6 @@
  */
 package org.reaktivity.nukleus.http.internal.stream;
 
-import java.util.function.Function;
 import java.util.function.IntUnaryOperator;
 import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
@@ -40,8 +39,6 @@ public final class ClientStreamFactoryBuilder implements StreamFactoryBuilder
     private LongSupplier supplyStreamId;
     private LongSupplier supplyCorrelationId;
     private Supplier<BufferPool> supplyBufferPool;
-    private LongSupplier incrementEnqueues;
-    private LongSupplier incrementDequeues;
 
     public ClientStreamFactoryBuilder(
         Configuration config)
@@ -97,15 +94,6 @@ public final class ClientStreamFactoryBuilder implements StreamFactoryBuilder
     }
 
     @Override
-    public StreamFactoryBuilder setCounterSupplier(
-        Function<String, LongSupplier> supplyCounter)
-    {
-        incrementEnqueues = supplyCounter.apply("enqueues");
-        incrementDequeues = supplyCounter.apply("dequeues");
-        return this;
-    }
-
-    @Override
     public StreamFactoryBuilder setBufferPoolSupplier(
         Supplier<BufferPool> supplyBufferPool)
     {
@@ -119,6 +107,6 @@ public final class ClientStreamFactoryBuilder implements StreamFactoryBuilder
         final BufferPool bufferPool = supplyBufferPool.get();
 
         return new ClientStreamFactory((HttpConfiguration) config, router, writeBuffer, bufferPool,
-                supplyStreamId, supplyCorrelationId, incrementEnqueues, incrementDequeues, correlations);
+                supplyStreamId, supplyCorrelationId, correlations);
     }
 }

--- a/src/main/java/org/reaktivity/nukleus/http/internal/stream/ConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/stream/ConnectionPool.java
@@ -31,25 +31,27 @@ final class ConnectionPool
 {
     public enum CloseAction
     {
-        END, ABORT;
-    };
+        END, ABORT
+    }
     private final Deque<Connection> availableConnections;
     private final String connectName;
     private final long connectRef;
     private final ClientStreamFactory factory;
 
     private int connectionsInUse;
-    private ConnectionRequest nextRequest;
 
     ConnectionPool(ClientStreamFactory factory, String connectName, long connectRef)
     {
         this.factory = factory;
         this.connectName = connectName;
         this.connectRef = connectRef;
-        this.availableConnections = new ArrayDeque<Connection>(factory.maximumConnectionsPerRoute);
+        this.availableConnections = new ArrayDeque<>(factory.maximumConnectionsPerRoute);
     }
 
-    public void acquire(ConnectionRequest request)
+    /*
+     * @return true if a connection is acquired, otherwise false
+     */
+    boolean acquire(ConnectionRequest request)
     {
         Connection connection = availableConnections.poll();
         if (connection == null && connectionsInUse < factory.maximumConnectionsPerRoute)
@@ -59,32 +61,10 @@ final class ConnectionPool
         if (connection != null)
         {
             request.getConsumer().accept(connection);
+            return true;
         }
-        else
-        {
-            enqueue(request);
-        }
-    }
 
-    public void cancel(ConnectionRequest request)
-    {
-        ConnectionRequest candidate = nextRequest;
-        ConnectionRequest prior = null;
-        while (request != candidate)
-        {
-            assert candidate != null;
-            prior = candidate;
-            candidate = candidate.next();
-        }
-        if (prior == null)
-        {
-            nextRequest = null;
-        }
-        else
-        {
-            prior.next(candidate.next());
-        }
-        factory.incrementDequeues.getAsLong();
+        return false;
     }
 
     private Connection newConnection()
@@ -99,12 +79,12 @@ final class ConnectionPool
         return connection;
     }
 
-    public void release(Connection connection)
+    void release(Connection connection)
     {
         release(connection, null);
     }
 
-    public void release(Connection connection, CloseAction action)
+    void release(Connection connection, CloseAction action)
     {
         final Correlation<?> correlation = factory.correlations.remove(connection.correlationId);
         if (correlation != null)
@@ -127,7 +107,13 @@ final class ConnectionPool
         }
         else
         {
-            connectionsInUse--;
+            // release() gets called multiple times for a connection
+            if (!connection.released)
+            {
+                connection.released = true;
+                connectionsInUse--;
+                assert connectionsInUse >= 0;
+            }
 
             // In case the connection was previously released when it was still persistent
             availableConnections.removeFirstOccurrence(connection);
@@ -146,54 +132,26 @@ final class ConnectionPool
                 connection.endOrAbortSent = true;
             }
         }
-        if (nextRequest != null)
-        {
-            ConnectionRequest current = nextRequest;
-            nextRequest = nextRequest.next();
-            factory.incrementDequeues.getAsLong();
-            acquire(current);
-        }
     }
 
-    public void setDefaultThrottle(Connection connection)
+    void setDefaultThrottle(Connection connection)
     {
         factory.router.setThrottle(connectName, connection.connectStreamId, connection::handleThrottleDefault);
-    }
-
-    private void enqueue(ConnectionRequest request)
-    {
-        if (this.nextRequest == null)
-        {
-            this.nextRequest = request;
-        }
-        else
-        {
-            ConnectionRequest latest = this.nextRequest;
-            while (latest.next() != null)
-            {
-                latest = latest.next();
-            }
-            latest.next(request);
-        }
-        factory.incrementEnqueues.getAsLong();
     }
 
     public interface ConnectionRequest
     {
         Consumer<Connection> getConsumer();
-
-        void next(ConnectionRequest next);
-
-        ConnectionRequest next();
     }
 
-    public class Connection
+    class Connection
     {
         final long connectStreamId;
         final long correlationId;
         int budget;
         int padding;
         boolean persistent = true;
+        boolean released;
         private boolean endOrAbortSent;
 
         private long connectReplyStreamId;

--- a/src/main/java/org/reaktivity/nukleus/http/internal/stream/ConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/stream/ConnectionPool.java
@@ -51,7 +51,7 @@ final class ConnectionPool
     /*
      * @return true if a connection is acquired, otherwise false
      */
-    boolean acquire(ConnectionRequest request)
+    Connection acquire(ConnectionRequest request)
     {
         Connection connection = availableConnections.poll();
         if (connection == null && connectionsInUse < factory.maximumConnectionsPerRoute)
@@ -61,10 +61,9 @@ final class ConnectionPool
         if (connection != null)
         {
             request.getConsumer().accept(connection);
-            return true;
         }
 
-        return false;
+        return connection;
     }
 
     private Connection newConnection()

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
@@ -16,7 +16,6 @@
 package org.reaktivity.nukleus.http.internal.streams.rfc7230.client;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
 import static org.junit.rules.RuleChain.outerRule;
 
 import org.junit.Ignore;
@@ -58,7 +57,7 @@ public class ConnectionManagementPoolSize1IT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/concurrent.requests/client",
+        "${client}/multiple.requests.same.connection/client",
         "${server}/multiple.requests.same.connection/server" })
     // With connection pool size limited to one the second concurrent request
     // must wait to use the same single connection
@@ -80,8 +79,8 @@ public class ConnectionManagementPoolSize1IT
     {
         k3po.start();
         k3po.awaitBarrier("REQUEST_ONE_RECEIVED");
-        k3po.awaitBarrier("REQUEST_TWO_RECEIVED");
         k3po.notifyBarrier("WRITE_DATA_REQUEST_ONE");
+        k3po.awaitBarrier("REQUEST_TWO_RECEIVED");
         k3po.notifyBarrier("WRITE_DATA_REQUEST_TWO");
         k3po.finish();
     }
@@ -152,20 +151,6 @@ public class ConnectionManagementPoolSize1IT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/pending.request.second.request.and.abort/client",
-        "${server}/pending.request.second.request.and.abort/server"})
-    public void shouldLeaveTransportUntouchedWhenEnqueuedRequestIsAborted() throws Exception
-    {
-        assertEquals(0, counters.enqueues());
-        assertEquals(0, counters.dequeues());
-        k3po.finish();
-        assertEquals(1, counters.enqueues());
-        assertEquals(1, counters.dequeues());
-    }
-
-    @Test
-    @Specification({
-        "${route}/client/controller",
         "${client}/request.receive.reset/client",
         "${server}/partial.request.receive.reset/server"})
     public void shouldResetRequestAndFreeConnectionWhenLowLevelIsReset() throws Exception
@@ -229,16 +214,6 @@ public class ConnectionManagementPoolSize1IT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/request.and.response.with.incomplete.data/client",
-        "${server}/request.response.headers.incomplete.data.and.reset/server" })
-    public void shouldFreeConnectionWhenConnectStreamIsResetBeforeResponseDataIsComplete() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
-        "${route}/client/controller",
         "${client}/response.with.content.length.is.reset/client",
         "${server}/response.with.content.length.is.reset/server" })
     public void shouldResetRequestAndFreeConnectionWhenRequestWithContentLengthIsReset() throws Exception
@@ -246,4 +221,13 @@ public class ConnectionManagementPoolSize1IT
         k3po.finish();
     }
 
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/503.with.retry.after/client",
+        "${server}/503.with.retry.after/server" })
+    public void shouldSend503WithRetryAfterForSecondRequest() throws Exception
+    {
+        k3po.finish();
+    }
 }


### PR DESCRIPTION
If the connection pool runs of connections, it sends 503 status with
Retry-After. This means requests are not enqueued (and buffer slots are
not used)