### PR TITLE
Request queue in http client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.22</nukleus.version>
 
-    <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
+    <nukleus.http.spec.version>0.58</nukleus.http.spec.version>
     <reaktor.version>0.59</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.22</nukleus.version>
 
-    <nukleus.http.spec.version>0.57</nukleus.http.spec.version>
+    <nukleus.http.spec.version>develop-SNAPSHOT</nukleus.http.spec.version>
     <reaktor.version>0.59</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/http/internal/HttpConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/HttpConfiguration.java
@@ -23,7 +23,12 @@ public class HttpConfiguration extends Configuration
     // the HTTP nukleus is acting as a client
     public static final String MAXIMUM_CONNECTIONS_PROPERTY_NAME = "nukleus.http.maximum.connections";
 
+    public static final String MAXIMUM_QUEUED_REQUESTS_PROPERTY_NAME = "nukleus.http.maximum.requests.queued";
+
+
     private static final int MAXIMUM_CONNECTIONS_DEFAULT = 10; // most browsers use 6, IE 11 uses 13
+    private static final int MAXIMUM_REQUESTS_QUEUED_DEFAULT = 10000;
+
 
     public HttpConfiguration(
         Configuration config)
@@ -36,4 +41,8 @@ public class HttpConfiguration extends Configuration
         return getInteger(MAXIMUM_CONNECTIONS_PROPERTY_NAME, MAXIMUM_CONNECTIONS_DEFAULT);
     }
 
+    public int maximumRequestsQueuedPerRoute()
+    {
+        return getInteger(MAXIMUM_QUEUED_REQUESTS_PROPERTY_NAME, MAXIMUM_REQUESTS_QUEUED_DEFAULT);
+    }
 }

--- a/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientAcceptStream.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientAcceptStream.java
@@ -218,7 +218,7 @@ final class ClientAcceptStream implements ConnectionRequest, Consumer<Connection
                                 .item(h -> h.name("retry-after").value("0")));
                 factory.writer.doHttpEnd(acceptReply, targetId, 0L);
 
-                // count rejected requests (no connection)
+                // count rejected requests (no connection or no space in the queue)
                 factory.countRequestsRejected.getAsLong();
             }
         }

--- a/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientAcceptStream.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientAcceptStream.java
@@ -15,7 +15,6 @@
  */
 package org.reaktivity.nukleus.http.internal.stream;
 
-import static org.reaktivity.nukleus.buffer.BufferPool.NO_SLOT;
 import static org.reaktivity.nukleus.http.internal.util.HttpUtil.appendHeader;
 
 import java.nio.charset.StandardCharsets;
@@ -24,9 +23,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import org.agrona.DirectBuffer;
-import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Long2ObjectHashMap;
-import org.reaktivity.nukleus.buffer.BufferPool;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.reaktivity.nukleus.function.MessageConsumer;
 import org.reaktivity.nukleus.http.internal.stream.ConnectionPool.CloseAction;
 import org.reaktivity.nukleus.http.internal.stream.ConnectionPool.Connection;
@@ -59,9 +57,9 @@ final class ClientAcceptStream implements ConnectionRequest, Consumer<Connection
     private ConnectionRequest nextConnectionRequest;
     private ConnectionPool connectionPool;
     private int sourceBudget;
-    private int slotIndex;
-    private int slotPosition;
-    private int slotOffset;
+    private DirectBuffer headersBuffer;
+    private int headersPosition;
+    private int headersOffset;
     private boolean endDeferred;
     private boolean persistent = true;
     private long traceId;
@@ -176,12 +174,10 @@ final class ClientAcceptStream implements ConnectionRequest, Consumer<Connection
         case EndFW.TYPE_ID:
             factory.endRO.wrap(buffer, index, index + length);
             this.streamState = this::streamAfterEndOrAbort;
-            releaseSlotIfNecessary();
             break;
         case AbortFW.TYPE_ID:
             factory.abortRO.wrap(buffer, index, index + length);
             this.streamState = this::streamAfterEndOrAbort;
-            releaseSlotIfNecessary();
             break;
         }
     }
@@ -193,52 +189,40 @@ final class ClientAcceptStream implements ConnectionRequest, Consumer<Connection
     {
         // count all requests
         factory.countRequests.getAsLong();
-
-        slotIndex = this.factory.bufferPool.acquire(acceptId);
-        if (slotIndex == BufferPool.NO_SLOT)
+        byte[] bytes = encodeHeaders(headers, buffer, index, length);
+        headers = null; // allow gc
+        headersPosition = 0;
+        if (bytes.length > factory.bufferPool.slotCapacity())
         {
+            // TODO: diagnostics (reset reason?)
             factory.writer.doReset(acceptThrottle, acceptId, 0L);
-            this.streamState = this::streamAfterReplyOrReset;
         }
         else
         {
-            byte[] bytes = encodeHeaders(headers, buffer, index, length);
-            headers = null; // allow gc
-            slotPosition = 0;
-            MutableDirectBuffer slot = factory.bufferPool.buffer(slotIndex);
-            if (bytes.length > slot.capacity())
+            traceId = factory.frameRO.wrap(buffer, index, index + length).trace();
+            headersBuffer = new UnsafeBuffer(bytes);
+            headersPosition = bytes.length;
+            headersOffset = 0;
+            this.streamState = this::streamBeforeHeadersWritten;
+            this.throttleState = this::throttleBeforeHeadersWritten;
+            target = factory.router.supplyTarget(connectName);
+            connectionPool = getConnectionPool(connectName, connectRef);
+            boolean acquired = connectionPool.acquire(this);
+            // No backend connection or cannot store in queue, send 503 with Retry-After
+            if (!acquired)
             {
-                // TODO: diagnostics (reset reason?)
-                factory.writer.doReset(acceptThrottle, acceptId, 0L);
-                releaseSlotIfNecessary();
-            }
-            else
-            {
-                traceId = factory.frameRO.wrap(buffer, index, index + length).trace();
-                slot.putBytes(0, bytes);
-                slotPosition = bytes.length;
-                slotOffset = 0;
-                this.streamState = this::streamBeforeHeadersWritten;
-                this.throttleState = this::throttleBeforeHeadersWritten;
-                target = factory.router.supplyTarget(connectName);
-                connectionPool = getConnectionPool(connectName, connectRef);
-                Connection connection = connectionPool.acquire(this);
-                // No backend connection, send 503 with Retry-After
-                if (connection == null)
-                {
-                    MessageConsumer acceptReply = factory.router.supplyTarget(acceptName);
-                    long targetId = factory.supplyStreamId.getAsLong();
-                    factory.writer.doHttpBegin(acceptReply, targetId, 0L, 0L, acceptCorrelationId,
-                            hs -> hs.item(h -> h.name(":status").value("503"))
-                                    .item(h -> h.name("retry-after").value("0")));
-                    factory.writer.doHttpEnd(acceptReply, targetId, 0L);
-                    releaseSlotIfNecessary();
+                MessageConsumer acceptReply = factory.router.supplyTarget(acceptName);
+                long targetId = factory.supplyStreamId.getAsLong();
+                factory.writer.doHttpBegin(acceptReply, targetId, 0L, 0L, acceptCorrelationId,
+                        hs -> hs.item(h -> h.name(":status").value("503"))
+                                .item(h -> h.name("retry-after").value("0")));
+                factory.writer.doHttpEnd(acceptReply, targetId, 0L);
 
-                    // count rejected requests (no connection)
-                    factory.countRequestsRejected.getAsLong();
-                }
+                // count rejected requests (no connection)
+                factory.countRequestsRejected.getAsLong();
             }
         }
+
     }
 
     private byte[] encodeHeaders(Map<String, String> headers,
@@ -357,7 +341,6 @@ final class ClientAcceptStream implements ConnectionRequest, Consumer<Connection
     {
         connectionPool.setDefaultThrottle(connection);
         this.streamState = this::streamAfterEndOrAbort;
-        releaseSlotIfNecessary();
     }
 
     private void processUnexpected(
@@ -371,7 +354,6 @@ final class ClientAcceptStream implements ConnectionRequest, Consumer<Connection
         factory.writer.doReset(acceptThrottle, streamId, 0);
 
         this.streamState = this::streamAfterReplyOrReset;
-        releaseSlotIfNecessary();
     }
 
     private void handleThrottle(
@@ -450,19 +432,17 @@ final class ClientAcceptStream implements ConnectionRequest, Consumer<Connection
 
     private void useWindowToWriteRequestHeaders()
     {
-        int writableBytes = Math.min(slotPosition - slotOffset, connection.budget - connection.padding);
+        int writableBytes = Math.min(headersPosition - headersOffset, connection.budget - connection.padding);
         if (writableBytes > 0)
         {
-            MutableDirectBuffer slot = this.factory.bufferPool.buffer(slotIndex);
-            factory.writer.doData(target, connection.connectStreamId, traceId, connection.padding, slot,
-                    slotOffset, writableBytes);
+            factory.writer.doData(target, connection.connectStreamId, traceId, connection.padding, headersBuffer,
+                    headersOffset, writableBytes);
             connection.budget -= writableBytes + connection.padding;
             assert connection.budget >= 0;
-            slotOffset += writableBytes;
-            int bytesDeferred = slotPosition - slotOffset;
+            headersOffset += writableBytes;
+            int bytesDeferred = headersPosition - headersOffset;
             if (bytesDeferred == 0)
             {
-                releaseSlotIfNecessary();
                 if (endDeferred)
                 {
                     doEnd();
@@ -496,9 +476,13 @@ final class ClientAcceptStream implements ConnectionRequest, Consumer<Connection
         int length)
     {
         factory.abortRO.wrap(buffer, index, index + length);
-        releaseSlotIfNecessary();
 
-        if (connection != null)
+        if (connection == null)
+        {
+            // request still enqueued, remove it from the queue
+            connectionPool.cancel(this);
+        }
+        else
         {
             factory.correlations.remove(connection.correlationId);
             connection.persistent = false;
@@ -512,19 +496,9 @@ final class ClientAcceptStream implements ConnectionRequest, Consumer<Connection
         int length)
     {
         ResetFW resetFW = factory.resetRO.wrap(buffer, index, index + length);
-        releaseSlotIfNecessary();
         connection.persistent = false;
         connectionPool.release(connection);
         factory.writer.doReset(acceptThrottle, acceptId, resetFW.trace());
-    }
-
-    private void releaseSlotIfNecessary()
-    {
-        if (slotIndex != NO_SLOT)
-        {
-            factory.bufferPool.release(slotIndex);
-            slotIndex = NO_SLOT;
-        }
     }
 
     @Override

--- a/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/stream/ClientStreamFactory.java
@@ -79,6 +79,8 @@ public final class ClientStreamFactory implements StreamFactory
     final RouteManager router;
     final LongSupplier supplyStreamId;
     final LongSupplier supplyCorrelationId;
+    final LongSupplier enqueues;
+    final LongSupplier dequeues;
     final BufferPool bufferPool;
     final MessageWriter writer;
     long supplyTraceId;
@@ -89,6 +91,8 @@ public final class ClientStreamFactory implements StreamFactory
 
     final Map<String, Map<Long, ConnectionPool>> connectionPools;
     final int maximumConnectionsPerRoute;
+    final int maximumQueuedRequestsPerRoute;
+
 
     final UnsafeBuffer temporarySlot;
     final LongSupplier countRequests;
@@ -115,6 +119,7 @@ public final class ClientStreamFactory implements StreamFactory
         this.correlations = requireNonNull(correlations);
         this.connectionPools = new HashMap<>();
         this.maximumConnectionsPerRoute = configuration.maximumConnectionsPerRoute();
+        this.maximumQueuedRequestsPerRoute = configuration.maximumRequestsQueuedPerRoute();
         this.maximumHeadersSize = bufferPool.slotCapacity();
         this.temporarySlot = new UnsafeBuffer(ByteBuffer.allocateDirect(bufferPool.slotCapacity()));
         this.countRequests = supplyCounter.apply("requests");
@@ -122,6 +127,8 @@ public final class ClientStreamFactory implements StreamFactory
         this.countRequestsAbandoned = supplyCounter.apply("requests.abandoned");
         this.countResponses = supplyCounter.apply("responses");
         this.countResponsesAbandoned = supplyCounter.apply("responses.abandoned");
+        this.enqueues = supplyCounter.apply("enqueues");
+        this.dequeues = supplyCounter.apply("dequeues");
     }
 
     @Override

--- a/src/main/java/org/reaktivity/nukleus/http/internal/stream/ConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/http/internal/stream/ConnectionPool.java
@@ -16,9 +16,8 @@
 package org.reaktivity.nukleus.http.internal.stream;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Deque;
-import java.util.List;
+import java.util.Queue;
 import java.util.function.Consumer;
 
 import org.agrona.DirectBuffer;
@@ -36,10 +35,10 @@ final class ConnectionPool
         END, ABORT
     }
     private final Deque<Connection> availableConnections;
-    private final List<Connection> acquiredConnections;
     private final String connectName;
     private final long connectRef;
     private final ClientStreamFactory factory;
+    private final Queue<ConnectionRequest> requests;
 
     private int connectionsInUse;
 
@@ -49,13 +48,13 @@ final class ConnectionPool
         this.connectName = connectName;
         this.connectRef = connectRef;
         this.availableConnections = new ArrayDeque<>(factory.maximumConnectionsPerRoute);
-        this.acquiredConnections = new ArrayList<>();
+        this.requests = new ArrayDeque<>(factory.maximumQueuedRequestsPerRoute);
     }
 
     /*
-     * @return true if a connection is acquired, otherwise false
+     * @return true if the given request is served immediately or later, otherwise false
      */
-    Connection acquire(ConnectionRequest request)
+    boolean acquire(ConnectionRequest request)
     {
         Connection connection = availableConnections.poll();
         if (connection == null && connectionsInUse < factory.maximumConnectionsPerRoute)
@@ -67,10 +66,35 @@ final class ConnectionPool
             connection.noRequests++;
             request.getConsumer().accept(connection);
         }
+        else if (requests.size() + 1 < factory.maximumQueuedRequestsPerRoute)
+        {
+            requests.add(request);
+            factory.enqueues.getAsLong();
+        }
+        else
+        {
+            return false;
+        }
 
-        acquiredConnections.add(connection);
+        return true;
+    }
 
-        return connection;
+    private void acquireNext(ConnectionRequest request)
+    {
+        Connection connection = availableConnections.poll();
+        if (connection == null && connectionsInUse < factory.maximumConnectionsPerRoute)
+        {
+            connection = newConnection();
+        }
+        assert connection != null;
+        connection.noRequests++;
+        request.getConsumer().accept(connection);
+    }
+
+    void cancel(ConnectionRequest request)
+    {
+        requests.remove(request);
+        factory.dequeues.getAsLong();
     }
 
     private Connection newConnection()
@@ -113,7 +137,6 @@ final class ConnectionPool
         {
             setDefaultThrottle(connection);
             availableConnections.add(connection);
-            acquiredConnections.remove(connection);
         }
         else
         {
@@ -127,7 +150,6 @@ final class ConnectionPool
 
             // In case the connection was previously released when it was still persistent
             availableConnections.removeFirstOccurrence(connection);
-            acquiredConnections.remove(connection); // first occurrence
 
             if (action != null && !connection.endOrAbortSent)
             {
@@ -142,6 +164,12 @@ final class ConnectionPool
                 }
                 connection.endOrAbortSent = true;
             }
+        }
+        ConnectionRequest nextRequest = requests.poll();
+        if (nextRequest != null)
+        {
+            acquireNext(nextRequest);
+            factory.dequeues.getAsLong();
         }
     }
 

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
@@ -16,6 +16,7 @@
 package org.reaktivity.nukleus.http.internal.streams.rfc7230.client;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
 import static org.junit.rules.RuleChain.outerRule;
 import static org.reaktivity.nukleus.http.internal.HttpConfiguration.MAXIMUM_QUEUED_REQUESTS_PROPERTY_NAME;
 
@@ -59,7 +60,7 @@ public class ConnectionManagementPoolSize1IT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/multiple.requests.same.connection/client",
+        "${client}/concurrent.requests/client",
         "${server}/multiple.requests.same.connection/server" })
     // With connection pool size limited to one the second concurrent request
     // must wait to use the same single connection
@@ -148,6 +149,20 @@ public class ConnectionManagementPoolSize1IT
     public void shouldAbortTransportAndFreeConnectionWhenRequestIsAborted() throws Exception
     {
         k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/pending.request.second.request.and.abort/client",
+        "${server}/pending.request.second.request.and.abort/server"})
+    public void shouldLeaveTransportUntouchedWhenEnqueuedRequestIsAborted() throws Exception
+    {
+        assertEquals(0, counters.enqueues());
+        assertEquals(0, counters.dequeues());
+        k3po.finish();
+        assertEquals(1, counters.enqueues());
+        assertEquals(1, counters.dequeues());
     }
 
     @Test

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
@@ -248,5 +248,6 @@ public class ConnectionManagementPoolSize1IT
     public void shouldSend503WithRetryAfterForSecondRequest() throws Exception
     {
         k3po.finish();
+        assertEquals(1, counters.requestsRejected());
     }
 }

--- a/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
@@ -17,6 +17,7 @@ package org.reaktivity.nukleus.http.internal.streams.rfc7230.client;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
+import static org.reaktivity.nukleus.http.internal.HttpConfiguration.MAXIMUM_QUEUED_REQUESTS_PROPERTY_NAME;
 
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -29,6 +30,7 @@ import org.kaazing.k3po.junit.rules.K3poRule;
 import org.reaktivity.nukleus.http.internal.HttpConfiguration;
 import org.reaktivity.nukleus.http.internal.test.HttpCountersRule;
 import org.reaktivity.reaktor.test.ReaktorRule;
+import org.reaktivity.reaktor.test.annotation.Configure;
 
 public class ConnectionManagementPoolSize1IT
 {
@@ -222,6 +224,7 @@ public class ConnectionManagementPoolSize1IT
         k3po.finish();
     }
 
+    @Configure(name = MAXIMUM_QUEUED_REQUESTS_PROPERTY_NAME, value = "0")
     @Test
     @Specification({
         "${route}/client/controller",

--- a/src/test/java/org/reaktivity/nukleus/http/internal/test/HttpCountersRule.java
+++ b/src/test/java/org/reaktivity/nukleus/http/internal/test/HttpCountersRule.java
@@ -73,6 +73,11 @@ public class HttpCountersRule implements TestRule
         return controller().count("dequeues");
     }
 
+    public long requestsRejected()
+    {
+        return controller().count("requests.rejected");
+    }
+
     private HttpController controller()
     {
         return reaktor.controller(HttpController.class);


### PR DESCRIPTION
- Adding a bounded queue for requests
- Sends 503+retry-after=0 if there are no connections and there is no space in the queue
- Queued requests use heap to store headers